### PR TITLE
Add Burndown chart on version detail

### DIFF
--- a/app/views/ui_extension/_burndown_chart.html.erb
+++ b/app/views/ui_extension/_burndown_chart.html.erb
@@ -1,0 +1,15 @@
+<% if version && chart_data = issues_burndown_chart_data(version) %>
+  <div id="version-detail-chart"><canvas id="burndown-chart"></canvas></div>'
+  <%= stylesheet_link_tag('../burndown_chart/stylesheets/burndown_chart.css', plugin: 'redmica_ui_extension') %>
+  <%= javascript_include_tag('Chart.bundle.min') %>
+  <%= javascript_include_tag('../burndown_chart/javascripts/burndown_chart.js', plugin: 'redmica_ui_extension') %>
+  <%= javascript_tag do %>
+      $(function() {
+        var title = '<%= I18n.t('redmica_ui_extension.burndown_chart.label_issues_burndown') %>';
+        var y_label = '<%= I18n.t('redmica_ui_extension.burndown_chart.label_issues_burndown_y_label') %>';
+        var y_lim = <%= version.fixed_issues.count %>;
+        var chartData = <%= chart_data.to_json.html_safe %>;
+        renderChart('#burndown-chart', title, y_label, y_lim, chartData);
+      });
+  <% end %>
+<% end %>

--- a/assets/burndown_chart/javascripts/burndown_chart.js
+++ b/assets/burndown_chart/javascripts/burndown_chart.js
@@ -1,0 +1,32 @@
+function renderChart(canvas_id, title, y_label, y_lim, chartData){
+  new Chart($(canvas_id), {
+    type: 'line',
+    data: chartData,
+    options: {
+      responsive: true,
+      legend: {
+        position: 'right',
+        labels: { boxWidth: 20, fontSize: 10, padding: 10 }
+      },
+      title: { display: true, text: title },
+      tooltips: {
+        callbacks: {
+          title: function(tooltipItem, data) { return '' }
+        }
+      },
+      scales: {
+        xAxes: [{
+          type: "time",
+          time: { unit: "day", displayFormats: { day: 'YYYY-MM-DD' } },
+          gridLines: { borderDash: [6, 4] },
+          ticks: { source: 'labels', autoSkip: true }
+        }],
+        yAxes: [{
+          scaleLabel: { display: true, labelString: y_label },
+          gridLines: { borderDash: [6, 4] },
+          ticks: { min: 0, max: y_lim, stepSize: 1 }
+        }]
+      }
+    }
+  });
+}

--- a/assets/burndown_chart/stylesheets/burndown_chart.css
+++ b/assets/burndown_chart/stylesheets/burndown_chart.css
@@ -1,0 +1,5 @@
+body.controller-versions.action-show #version-detail-chart { width: 70%; margin: 2em 0 }
+@media screen and (max-width: 899px)
+{
+  body.controller-versions.action-show #version-detail-chart {width:100%;}
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,3 +2,9 @@ en:
   redmica_ui_extension:
     searchable_selectbox:
       label_enable: Make the selection box searchable
+    burndown_chart:
+      label_issues_burndown: burndown
+      label_issues_burndown_y_label: Number of Issues
+      label_ideal_line: Ideal
+      label_total_substract_closed_line: Total - Closed
+      label_open_line: Open

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,3 +2,9 @@ ja:
   redmica_ui_extension:
     searchable_selectbox:
       label_enable: セレクトボックスを検索可能にする
+    burndown_chart:
+      label_issues_burndown: バーンダウンチャート
+      label_issues_burndown_y_label: チケット数
+      label_ideal_line: 理想線
+      label_total_substract_closed_line: 合計 - 完了
+      label_open_line: 未完了

--- a/init_redmica_ui_extension.rb
+++ b/init_redmica_ui_extension.rb
@@ -6,3 +6,10 @@ require_dependency 'searchable_selectbox/my_helper_patch'
 Rails.configuration.to_prepare do
   MyHelper.__send__(:include, SearchableSelectbox::MyHelperPatch)
 end
+
+# burndown_chart
+require_dependency 'burndown_chart/hook_listener'
+require_dependency 'burndown_chart/versions_helper_patch'
+Rails.configuration.to_prepare do
+  VersionsHelper.__send__(:include, BurndownChart::VersionsHelperPatch)
+end

--- a/lib/burndown_chart/hook_listener.rb
+++ b/lib/burndown_chart/hook_listener.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module BurndownChart
+  class HookListener < Redmine::Hook::ViewListener
+    render_on :view_versions_show_bottom, partial: 'ui_extension/burndown_chart'
+  end
+end

--- a/lib/burndown_chart/versions_helper_patch.rb
+++ b/lib/burndown_chart/versions_helper_patch.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_dependency 'versions_helper'
+
+module BurndownChart
+  module VersionsHelperPatch
+    def self.included(base)
+      base.send(:prepend, InstanceMethods)
+    end
+
+    module InstanceMethods
+      def issues_burndown_chart_data(version)
+        return nil if version.visible_fixed_issues.empty?
+        chart_start_date = (version.start_date || version.created_on).to_date
+        chart_end_date = [version.due_date, version.visible_fixed_issues.maximum(:due_date), version.visible_fixed_issues.maximum(:updated_on)].compact.max.to_date
+        line_end_date = [User.current.today, chart_end_date].min
+        step_size = ((chart_start_date..chart_end_date).count.to_f / 90).ceil
+        issues = version.visible_fixed_issues
+        return nil if step_size < 1
+        total_closed = chart_start_date.step(line_end_date, step_size).collect{|d| {:t => d.to_s, :y => issues.where("#{Issue.table_name}.closed_on IS NULL OR #{Issue.table_name}.closed_on>=?", d.end_of_day).count}}
+        open = chart_start_date.step(line_end_date, step_size).collect{|d| {:t => d.to_s, :y => issues.where("#{Issue.table_name}.created_on<=?", d.end_of_day).count - issues.open(false).where("#{Issue.table_name}.closed_on<=?", d.end_of_day).count}}
+        chart_data = {
+          :labels => chart_start_date.step(chart_end_date, step_size).collect{|d|d.to_s},
+          :datasets => [
+            {:label => I18n.t('redmica_ui_extension.burndown_chart.label_ideal_line'), :data => [{:t => chart_start_date.to_s, :y => total_closed.first[:y]}, {:t => chart_end_date.to_s, :y => 0}],
+             :backgroundColor => "rgba(0, 0, 0, 0)",
+             :lineTension => 0, :borderWidth => 2, :borderDash => [5, 2], :spanGaps => true},
+            {:label => I18n.t('redmica_ui_extension.burndown_chart.label_total_substract_closed_line'), :data => total_closed,
+             :borderColor => "rgba(186, 224, 186, 1)", :backgroundColor => "rgba(0, 0, 0, 0)", :pointBackgroundColor => "rgba(186, 224, 186, 1)",
+             :lineTension => 0, :borderWidth => 2, :borderDash => [5, 2]},
+            {:label => I18n.t('redmica_ui_extension.burndown_chart.label_open_line'), :data => open,
+             :borderColor => "rgba(186, 224, 186, 1)", :backgroundColor => "rgba(186, 224, 186, 0.1)", :pointBackgroundColor => "rgba(186, 224, 186, 1)",
+             :lineTension => 0, :borderWidth => 2}
+          ]
+        }
+        return chart_data
+      end
+    end
+  end
+end

--- a/test/helpers/versions_helper_patch_test.rb
+++ b/test/helpers/versions_helper_patch_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../../../../test/test_helper', __FILE__)
+
+class VersionsHelperPatchTest < Redmine::HelperTest
+  include VersionsHelper
+  fixtures :projects, :enabled_modules,
+           :users, :members, :roles, :member_roles,
+           :trackers, :projects_trackers, :enumerations, :issue_statuses
+
+  def test_issues_burndown_chart_data_should_return_chart_data
+    User.any_instance.stubs(:today).returns(3.days.after.to_date)
+    version = Version.create!(:project => Project.find(1), :name => 'test', :due_date => 5.days.after.to_date)
+    issue = Issue.create!(:project => version.project, :fixed_version => version,
+                          :priority => IssuePriority.find_by_name('Normal'),
+                          :tracker => version.project.trackers.first, :subject => 'text', :author => User.current,
+                          :start_date => 1.days.after.to_date)
+    chart_data = {
+      :labels => (1.days.after.to_date..5.days.after.to_date).map { |d| d.to_s },
+      :datasets => [
+        {:label => I18n.t('redmica_ui_extension.burndown_chart.label_ideal_line'), :data => [{:t => 1.days.after.to_date.to_s, :y => 1}, {:t => 5.days.after.to_date.to_s, :y => 0}],
+         :backgroundColor => "rgba(0, 0, 0, 0)",
+         :lineTension => 0, :borderWidth => 2, :borderDash => [5, 2], :spanGaps => true},
+        {:label => I18n.t('redmica_ui_extension.burndown_chart.label_total_substract_closed_line'), :data => [{:t => 1.days.after.to_date.to_s, :y => 1}, {:t => 2.days.after.to_date.to_s, :y => 1}, {:t => 3.days.after.to_date.to_s, :y => 1}],
+         :borderColor => "rgba(186, 224, 186, 1)", :backgroundColor => "rgba(0, 0, 0, 0)", :pointBackgroundColor => "rgba(186, 224, 186, 1)",
+         :lineTension => 0, :borderWidth => 2, :borderDash => [5, 2]},
+        {:label => I18n.t('redmica_ui_extension.burndown_chart.label_open_line'), :data => [{:t => 1.days.after.to_date.to_s, :y => 1}, {:t => 2.days.after.to_date.to_s, :y => 1}, {:t => 3.days.after.to_date.to_s, :y => 1}],
+         :borderColor => "rgba(186, 224, 186, 1)", :backgroundColor => "rgba(186, 224, 186, 0.1)", :pointBackgroundColor => "rgba(186, 224, 186, 1)",
+         :lineTension => 0, :borderWidth => 2}
+      ]
+    }
+    assert_equal chart_data, issues_burndown_chart_data(version)
+  end
+
+  def test_issues_burndown_chart_data_should_return_nil_when_visible_fixed_issues_empty
+    version = Version.create!(:project => Project.find(1), :name => 'test')
+    version.visible_fixed_issues.destroy_all
+    assert_empty version.visible_fixed_issues
+    assert_nil issues_burndown_chart_data(version)
+  end
+
+  def test_issues_burndown_chart_data_should_return_nil_when_order_of_start_date_and_due_date_is_reversed
+    version = Version.create!(:project => Project.find(1), :name => 'test', :due_date => 10.days.after)
+    issue = Issue.create!(:project => version.project, :fixed_version => version,
+                          :priority => IssuePriority.find_by_name('Normal'),
+                          :tracker => version.project.trackers.first, :subject => 'text', :author => User.current,
+                          :start_date => 11.days.after)
+    assert_nil issues_burndown_chart_data(version)
+  end
+end

--- a/test/system/burndown_chart_test.rb
+++ b/test/system/burndown_chart_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../../../../test/application_system_test_case', __FILE__)
+
+class BurndownChartTest < ApplicationSystemTestCase
+  fixtures :projects, :enabled_modules, :versions,
+           :users, :members, :roles, :member_roles,
+           :trackers, :projects_trackers, :enumerations, :issue_statuses, :issues
+
+
+  def test_render_chart_on_version_detail
+    log_user('jsmith', 'jsmith')
+    visit '/versions/2'
+
+    assert page.has_css?('#version-detail-chart')
+    within '#version-detail-chart' do
+      assert page.find('#burndown-chart')
+    end
+  end
+
+  def test_does_not_render_chart_if_issues_empty
+    version = Version.find(2)
+    version.fixed_issues.delete_all
+
+    log_user('jsmith', 'jsmith')
+    visit '/versions/2'
+
+    assert page.has_no_css?('#version-detail-chart')
+    assert page.all(:css, '#version-detail-chart').empty?
+  end
+end


### PR DESCRIPTION
I propose a feature to visualize the changes of Open / Close issues in the version detail using 'Burndown chart'.

![issues burndown chart](https://user-images.githubusercontent.com/926014/110288405-4b49aa00-802b-11eb-997b-aa0905e10c91.png)