### PR TITLE
Add Burndown chart on version detail

### DIFF
--- a/app/views/settings/_redmica_ui_extension.html.erb
+++ b/app/views/settings/_redmica_ui_extension.html.erb
@@ -2,3 +2,7 @@
   <%= label_tag('settings[searchable_selectbox][enabled]', I18n.t('redmica_ui_extension.searchable_selectbox.label_enable')) %>
   <%= check_box_tag('settings[searchable_selectbox][enabled]', 1, settings['searchable_selectbox'].to_h['enabled']) %>
 </p>
+<p>
+  <%= label_tag('settings[burndown_chart][enabled]', I18n.t('redmica_ui_extension.burndown_chart.label_enable')) %>
+  <%= check_box_tag('settings[burndown_chart][enabled]', 1, settings['burndown_chart'].to_h['enabled']) %>
+</p>

--- a/app/views/ui_extension/_burndown_chart.html.erb
+++ b/app/views/ui_extension/_burndown_chart.html.erb
@@ -1,0 +1,15 @@
+<% if version && chart_data = issues_burndown_chart_data(version) %>
+  <div id="version-detail-chart"><canvas id="burndown-chart"></canvas></div>'
+  <%= stylesheet_link_tag('../burndown_chart/stylesheets/burndown_chart.css', plugin: 'redmica_ui_extension') %>
+  <%= javascript_include_tag('Chart.bundle.min') %>
+  <%= javascript_include_tag('../burndown_chart/javascripts/burndown_chart.js', plugin: 'redmica_ui_extension') %>
+  <%= javascript_tag do %>
+      $(function() {
+        var title = '<%= I18n.t('redmica_ui_extension.burndown_chart.label_issues_burndown') %>';
+        var y_label = '<%= I18n.t('redmica_ui_extension.burndown_chart.label_issues_burndown_y_label') %>';
+        var y_lim = <%= version.fixed_issues.count %>;
+        var chartData = <%= chart_data.to_json.html_safe %>;
+        renderChart('#burndown-chart', title, y_label, y_lim, chartData);
+      });
+  <% end %>
+<% end %>

--- a/app/views/ui_extension/_burndown_chart.html.erb
+++ b/app/views/ui_extension/_burndown_chart.html.erb
@@ -1,4 +1,4 @@
-<% if version && chart_data = issues_burndown_chart_data(version) %>
+<% if Setting.plugin_redmica_ui_extension['burndown_chart'].to_h['enabled'] && version && chart_data = issues_burndown_chart_data(version) %>
   <div id="version-detail-chart"><canvas id="burndown-chart"></canvas></div>'
   <%= stylesheet_link_tag('../burndown_chart/stylesheets/burndown_chart.css', plugin: 'redmica_ui_extension') %>
   <%= javascript_include_tag('Chart.bundle.min') %>

--- a/assets/burndown_chart/javascripts/burndown_chart.js
+++ b/assets/burndown_chart/javascripts/burndown_chart.js
@@ -1,0 +1,32 @@
+function renderChart(canvas_id, title, y_label, y_lim, chartData){
+  new Chart($(canvas_id), {
+    type: 'line',
+    data: chartData,
+    options: {
+      responsive: true,
+      legend: {
+        position: 'right',
+        labels: { boxWidth: 20, fontSize: 10, padding: 10 }
+      },
+      title: { display: true, text: title },
+      tooltips: {
+        callbacks: {
+          title: function(tooltipItem, data) { return '' }
+        }
+      },
+      scales: {
+        xAxes: [{
+          type: "time",
+          time: { unit: "day", displayFormats: { day: 'YYYY-MM-DD' } },
+          gridLines: { borderDash: [6, 4] },
+          ticks: { source: 'labels', autoSkip: true }
+        }],
+        yAxes: [{
+          scaleLabel: { display: true, labelString: y_label },
+          gridLines: { borderDash: [6, 4] },
+          ticks: { min: 0, max: y_lim, stepSize: 1 }
+        }]
+      }
+    }
+  });
+}

--- a/assets/burndown_chart/stylesheets/burndown_chart.css
+++ b/assets/burndown_chart/stylesheets/burndown_chart.css
@@ -1,0 +1,5 @@
+body.controller-versions.action-show #version-detail-chart { width: 70%; margin: 2em 0 }
+@media screen and (max-width: 899px)
+{
+  body.controller-versions.action-show #version-detail-chart {width:100%;}
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
     searchable_selectbox:
       label_enable: Make the selection box searchable
     burndown_chart:
+      label_enable: Display Burndown Chart
       label_issues_burndown: burndown
       label_issues_burndown_y_label: Number of Issues
       label_ideal_line: Ideal

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,3 +2,9 @@ en:
   redmica_ui_extension:
     searchable_selectbox:
       label_enable: Make the selection box searchable
+    burndown_chart:
+      label_issues_burndown: burndown
+      label_issues_burndown_y_label: Number of Issues
+      label_ideal_line: Ideal
+      label_total_substract_closed_line: Total - Closed
+      label_open_line: Open

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     searchable_selectbox:
       label_enable: セレクトボックスを検索可能にする
     burndown_chart:
+      label_enable: バーンダウンチャートを表示する
       label_issues_burndown: バーンダウンチャート
       label_issues_burndown_y_label: チケット数
       label_ideal_line: 理想線

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,3 +2,9 @@ ja:
   redmica_ui_extension:
     searchable_selectbox:
       label_enable: セレクトボックスを検索可能にする
+    burndown_chart:
+      label_issues_burndown: バーンダウンチャート
+      label_issues_burndown_y_label: チケット数
+      label_ideal_line: 理想線
+      label_total_substract_closed_line: 合計 - 完了
+      label_open_line: 未完了

--- a/init.rb
+++ b/init.rb
@@ -12,5 +12,5 @@ Redmine::Plugin.register :redmica_ui_extension do
   url 'https://github.com/redmica/redmica_ui_extension'
   author_url 'https://github.com/redmica'
 
-  settings default: {'searchable_selectbox' => {'enabled' => 1}}, partial: 'settings/redmica_ui_extension'
+  settings default: {'searchable_selectbox' => {'enabled' => 1}, 'burndown_chart' => {'enabled' => 1}}, partial: 'settings/redmica_ui_extension'
 end

--- a/init_redmica_ui_extension.rb
+++ b/init_redmica_ui_extension.rb
@@ -6,3 +6,10 @@ require_dependency 'searchable_selectbox/my_helper_patch'
 Rails.configuration.to_prepare do
   MyHelper.__send__(:include, SearchableSelectbox::MyHelperPatch)
 end
+
+# burndown_chart
+require_dependency 'burndown_chart/hook_listener'
+require_dependency 'burndown_chart/versions_helper_patch'
+Rails.configuration.to_prepare do
+  VersionsHelper.__send__(:include, BurndownChart::VersionsHelperPatch)
+end

--- a/init_redmica_ui_extension.rb
+++ b/init_redmica_ui_extension.rb
@@ -4,12 +4,12 @@
 require_dependency 'searchable_selectbox/hook_listener'
 require_dependency 'searchable_selectbox/my_helper_patch'
 Rails.configuration.to_prepare do
-  MyHelper.__send__(:include, SearchableSelectbox::MyHelperPatch)
+  MyHelper.include SearchableSelectbox::MyHelperPatch
 end
 
 # burndown_chart
 require_dependency 'burndown_chart/hook_listener'
 require_dependency 'burndown_chart/versions_helper_patch'
 Rails.configuration.to_prepare do
-  VersionsHelper.__send__(:include, BurndownChart::VersionsHelperPatch)
+  VersionsHelper.include BurndownChart::VersionsHelperPatch
 end

--- a/lib/burndown_chart/hook_listener.rb
+++ b/lib/burndown_chart/hook_listener.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module BurndownChart
+  class HookListener < Redmine::Hook::ViewListener
+    render_on :view_versions_show_bottom, partial: 'ui_extension/burndown_chart'
+  end
+end

--- a/lib/burndown_chart/versions_helper_patch.rb
+++ b/lib/burndown_chart/versions_helper_patch.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_dependency 'versions_helper'
+
+module BurndownChart
+  module VersionsHelperPatch
+    def self.included(base)
+      base.send(:prepend, InstanceMethods)
+    end
+
+    module InstanceMethods
+      def issues_burndown_chart_data(version)
+        return nil if version.visible_fixed_issues.empty?
+        chart_start_date = (version.start_date || version.created_on).to_date
+        chart_end_date = version.due_date || (version.completed? ? version.visible_fixed_issues.maximum(:closed_on) : User.current.today)
+        line_end_date = [User.current.today, chart_end_date].min
+        step_size = ((chart_start_date..chart_end_date).count.to_f / 90).ceil
+        issues = version.visible_fixed_issues
+        return nil if step_size < 1
+
+        ideal = [{ :t => chart_start_date.to_s, :y => issues.count }, { :t => version.due_date.to_s, :y => 0 }]
+        total_closed = chart_start_date.step(line_end_date, step_size).collect{ |d| { :t => d.to_s, :y => issues.where("#{Issue.table_name}.closed_on IS NULL OR #{Issue.table_name}.closed_on>=?", d.end_of_day).count } }
+        open = chart_start_date.step(line_end_date, step_size).collect{ |d| { :t => d.to_s, :y => issues.where("#{Issue.table_name}.created_on<=?", d.end_of_day).count - issues.open(false).where("#{Issue.table_name}.closed_on<=?", d.end_of_day).count } }
+
+        labels = chart_start_date.step(chart_end_date, step_size).collect{ |d| d.to_s }
+        datasets = []
+        if version.due_date
+          datasets << {:label => I18n.t('redmica_ui_extension.burndown_chart.label_ideal_line'), :data => ideal,
+                       :backgroundColor => "rgba(0, 0, 0, 0)",
+                       :lineTension => 0, :borderWidth => 2, :borderDash => [5, 2], :spanGaps => true}
+        end
+        datasets << {:label => I18n.t('redmica_ui_extension.burndown_chart.label_total_substract_closed_line'), :data => total_closed,
+                     :borderColor => "rgba(186, 224, 186, 1)", :backgroundColor => "rgba(0, 0, 0, 0)", :pointBackgroundColor => "rgba(186, 224, 186, 1)",
+                     :lineTension => 0, :borderWidth => 2, :borderDash => [5, 2]}
+        datasets << {:label => I18n.t('redmica_ui_extension.burndown_chart.label_open_line'), :data => open,
+                     :borderColor => "rgba(186, 224, 186, 1)", :backgroundColor => "rgba(186, 224, 186, 0.1)", :pointBackgroundColor => "rgba(186, 224, 186, 1)",
+                     :lineTension => 0, :borderWidth => 2}
+
+        return {:labels => labels, :datasets => datasets}
+      end
+    end
+  end
+end

--- a/lib/burndown_chart/versions_helper_patch.rb
+++ b/lib/burndown_chart/versions_helper_patch.rb
@@ -19,8 +19,9 @@ module BurndownChart
         return nil if step_size < 1
 
         ideal = [{ :t => chart_start_date.to_s, :y => issues.count }, { :t => version.due_date.to_s, :y => 0 }]
-        total_closed = chart_start_date.step(line_end_date, step_size).collect{ |d| { :t => d.to_s, :y => issues.where("#{Issue.table_name}.closed_on IS NULL OR #{Issue.table_name}.closed_on>=?", d.end_of_day).count } }
-        open = chart_start_date.step(line_end_date, step_size).collect{ |d| { :t => d.to_s, :y => issues.where("#{Issue.table_name}.created_on<=?", d.end_of_day).count - issues.open(false).where("#{Issue.table_name}.closed_on<=?", d.end_of_day).count } }
+        plot_dates = (chart_start_date.step(line_end_date, step_size).to_a + [line_end_date]).uniq
+        total_closed = plot_dates.collect{ |d| { :t => d.to_s, :y => issues.count - issues.open(false).where("#{Issue.table_name}.closed_on<=?", d.end_of_day).count } }
+        open = plot_dates.collect{ |d| { :t => d.to_s, :y => issues.where("#{Issue.table_name}.created_on<=?", d.end_of_day).count - issues.open(false).where("#{Issue.table_name}.closed_on<=?", d.end_of_day).count } }
 
         labels = chart_start_date.step(chart_end_date, step_size).collect{ |d| d.to_s }
         datasets = []

--- a/lib/burndown_chart/versions_helper_patch.rb
+++ b/lib/burndown_chart/versions_helper_patch.rb
@@ -12,7 +12,7 @@ module BurndownChart
       def issues_burndown_chart_data(version)
         return nil if version.visible_fixed_issues.empty?
         chart_start_date = (version.start_date || version.created_on).to_date
-        chart_end_date = version.due_date || (version.completed? ? version.visible_fixed_issues.maximum(:closed_on) : User.current.today)
+        chart_end_date = (version.due_date || (version.completed? ? version.visible_fixed_issues.maximum(:closed_on) : User.current.today)).to_date
         line_end_date = [User.current.today, chart_end_date].min
         step_size = ((chart_start_date..chart_end_date).count.to_f / 90).ceil
         issues = version.visible_fixed_issues

--- a/test/helpers/versions_helper_patch_test.rb
+++ b/test/helpers/versions_helper_patch_test.rb
@@ -99,6 +99,24 @@ class VersionsHelperPatchTest < Redmine::HelperTest
                   issue.closed_on.to_date.to_s], labels
   end
 
+  def test_issues_burndown_chart_data_should_return_chart_data_end_with_today
+    # 5 days ago (create version and issue)
+    travel_to 5.days.before
+    version = Version.create!(:project => Project.find(1), :name => 'test', :due_date => nil)
+    issue = Issue.create!(:project => version.project, :fixed_version => version,
+                          :priority => IssuePriority.find_by_name('Normal'), :tracker => version.project.trackers.first,
+                          :subject => "test issue", :author => User.current)
+    travel_back
+
+    # generate chart data
+    chart_data = issues_burndown_chart_data(version)
+    labels = chart_data[:labels]
+    datasets = chart_data[:datasets]
+
+    assert_equal 5.days.before.to_date.to_s, labels.first
+    assert_equal User.current.today.to_s, labels.last
+  end
+
   def test_issues_burndown_chart_data_should_return_chart_data_without_ideal
     version = Version.find(2)
     version.update(:due_date => nil)

--- a/test/helpers/versions_helper_patch_test.rb
+++ b/test/helpers/versions_helper_patch_test.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../../../../test/test_helper', __FILE__)
+
+class VersionsHelperPatchTest < Redmine::HelperTest
+  include VersionsHelper
+  fixtures :projects, :enabled_modules,
+           :users, :members, :roles, :member_roles,
+           :trackers, :projects_trackers, :enumerations, :issue_statuses
+
+  def test_issues_burndown_chart_data_should_return_chart_data
+    # 3 days ago
+    travel -3.day
+    version = Version.create!(:project => Project.find(1), :name => 'test', :due_date => 4.days.after.to_date)
+    2.times.each do |i|
+      Issue.create!(:project => version.project, :fixed_version => version,
+                    :priority => IssuePriority.find_by_name('Normal'), :tracker => version.project.trackers.first,
+                    :subject => "test issue #{i}", :author => User.current)
+    end
+    travel_back
+
+    # 2 days ago
+    travel -2.day
+    issue = version.fixed_issues.last
+    issue.status = IssueStatus.where(:is_closed => true).first
+    issue.save
+    travel_back
+
+    # yesterday
+    travel -1.day
+    issue = Issue.create!(:project => version.project, :fixed_version => version,
+                          :priority => IssuePriority.find_by_name('Normal'), :tracker => version.project.trackers.first,
+                          :subject => "test issue 2", :author => User.current)
+    travel_back
+
+    # today
+    issue.status = IssueStatus.where(:is_closed => true).first
+    issue.save
+
+    # generate chart data
+    chart_data = issues_burndown_chart_data(version)
+    labels = chart_data[:labels]
+    datasets = chart_data[:datasets]
+
+    # assert labels for xaxis
+    assert_equal [3.days.before.to_date.to_s,
+                  2.days.before.to_date.to_s,
+                  1.days.before.to_date.to_s,
+                  User.current.today.to_s,
+                  1.days.after.to_date.to_s], labels
+
+    # assert label in datasets
+    assert_equal I18n.t('redmica_ui_extension.burndown_chart.label_ideal_line'), datasets.first[:label]
+    assert_equal I18n.t('redmica_ui_extension.burndown_chart.label_total_substract_closed_line'), datasets.second[:label]
+    assert_equal I18n.t('redmica_ui_extension.burndown_chart.label_open_line'), datasets.last[:label]
+
+    # assert data for 'ideal' line
+    assert_equal [{:t => 3.days.before.to_date.to_s, :y => 3},
+                  {:t => 1.days.after.to_date.to_s, :y => 0}],
+                 datasets.first[:data]
+    # assert data for 'total - closed' line
+    assert_equal [{:t => 3.days.before.to_date.to_s, :y => 3},
+                  {:t => 2.days.before.to_date.to_s, :y => 2},
+                  {:t => 1.days.before.to_date.to_s, :y => 2},
+                  {:t => User.current.today.to_s, :y => 1}],
+                 datasets.second[:data]
+    # assert data for 'open' line
+    assert_equal [{:t => 3.days.before.to_date.to_s, :y => 2},
+                  {:t => 2.days.before.to_date.to_s, :y => 1},
+                  {:t => 1.days.before.to_date.to_s, :y => 2},
+                  {:t => User.current.today.to_s, :y => 1}],
+                 datasets.last[:data]
+  end
+
+  def test_issues_burndown_chart_data_should_return_chart_data_without_ideal
+    version = Version.find(2)
+    version.update(:due_date => nil)
+    version.stubs(:start_date).returns(3.days.before.to_date)
+
+    chart_data = issues_burndown_chart_data(version)
+    labels = chart_data[:labels]
+    datasets = chart_data[:datasets]
+
+    # assert labels for xaxis
+    assert_equal [3.days.before.to_date.to_s,
+                  2.days.before.to_date.to_s,
+                  1.days.before.to_date.to_s,
+                  User.current.today.to_s], labels
+
+    # assert label in datasets
+    assert_equal I18n.t('redmica_ui_extension.burndown_chart.label_total_substract_closed_line'), datasets.first[:label]
+    assert_equal I18n.t('redmica_ui_extension.burndown_chart.label_open_line'), datasets.last[:label]
+  end
+
+  def test_issues_burndown_chart_data_should_return_nil_when_visible_fixed_issues_empty
+    version = Version.create!(:project => Project.find(1), :name => 'test')
+    version.visible_fixed_issues.destroy_all
+    assert_empty version.visible_fixed_issues
+    assert_nil issues_burndown_chart_data(version)
+  end
+
+  def test_issues_burndown_chart_data_should_return_nil_when_order_of_start_date_and_due_date_is_reversed
+    version = Version.create!(:project => Project.find(1), :name => 'test', :due_date => 10.days.after)
+    issue = Issue.create!(:project => version.project, :fixed_version => version,
+                          :priority => IssuePriority.find_by_name('Normal'),
+                          :tracker => version.project.trackers.first, :subject => 'text', :author => User.current,
+                          :start_date => 11.days.after)
+    assert_nil issues_burndown_chart_data(version)
+  end
+end

--- a/test/helpers/versions_helper_patch_test.rb
+++ b/test/helpers/versions_helper_patch_test.rb
@@ -10,7 +10,7 @@ class VersionsHelperPatchTest < Redmine::HelperTest
 
   def test_issues_burndown_chart_data_should_return_chart_data
     # 3 days ago
-    travel -3.day
+    travel_to 3.days.before
     version = Version.create!(:project => Project.find(1), :name => 'test', :due_date => 4.days.after.to_date)
     2.times.each do |i|
       Issue.create!(:project => version.project, :fixed_version => version,
@@ -20,14 +20,14 @@ class VersionsHelperPatchTest < Redmine::HelperTest
     travel_back
 
     # 2 days ago
-    travel -2.day
+    travel_to 2.days.before
     issue = version.fixed_issues.last
     issue.status = IssueStatus.where(:is_closed => true).first
     issue.save
     travel_back
 
     # yesterday
-    travel -1.day
+    travel_to 1.day.before
     issue = Issue.create!(:project => version.project, :fixed_version => version,
                           :priority => IssuePriority.find_by_name('Normal'), :tracker => version.project.trackers.first,
                           :subject => "test issue 2", :author => User.current)
@@ -45,9 +45,9 @@ class VersionsHelperPatchTest < Redmine::HelperTest
     # assert labels for xaxis
     assert_equal [3.days.before.to_date.to_s,
                   2.days.before.to_date.to_s,
-                  1.days.before.to_date.to_s,
+                  1.day.before.to_date.to_s,
                   User.current.today.to_s,
-                  1.days.after.to_date.to_s], labels
+                  1.day.after.to_date.to_s], labels
 
     # assert label in datasets
     assert_equal I18n.t('redmica_ui_extension.burndown_chart.label_ideal_line'), datasets.first[:label]
@@ -56,25 +56,25 @@ class VersionsHelperPatchTest < Redmine::HelperTest
 
     # assert data for 'ideal' line
     assert_equal [{:t => 3.days.before.to_date.to_s, :y => 3},
-                  {:t => 1.days.after.to_date.to_s, :y => 0}],
+                  {:t => 1.day.after.to_date.to_s, :y => 0}],
                  datasets.first[:data]
     # assert data for 'total - closed' line
     assert_equal [{:t => 3.days.before.to_date.to_s, :y => 3},
                   {:t => 2.days.before.to_date.to_s, :y => 2},
-                  {:t => 1.days.before.to_date.to_s, :y => 2},
+                  {:t => 1.day.before.to_date.to_s, :y => 2},
                   {:t => User.current.today.to_s, :y => 1}],
                  datasets.second[:data]
     # assert data for 'open' line
     assert_equal [{:t => 3.days.before.to_date.to_s, :y => 2},
                   {:t => 2.days.before.to_date.to_s, :y => 1},
-                  {:t => 1.days.before.to_date.to_s, :y => 2},
+                  {:t => 1.day.before.to_date.to_s, :y => 2},
                   {:t => User.current.today.to_s, :y => 1}],
                  datasets.last[:data]
   end
 
   def test_issues_burndown_chart_data_should_return_chart_data_end_with_latest_issue_closed_on
     # 3 days ago (create version and issue)
-    travel -3.day
+    travel_to 3.days.before
     version = Version.create!(:project => Project.find(1), :name => 'test', :due_date => nil)
     issue = Issue.create!(:project => version.project, :fixed_version => version,
                           :priority => IssuePriority.find_by_name('Normal'), :tracker => version.project.trackers.first,
@@ -95,7 +95,7 @@ class VersionsHelperPatchTest < Redmine::HelperTest
     # assert labels for xaxis (end with latest issue closed_on)
     assert_equal [3.days.before.to_date.to_s,
                   2.days.before.to_date.to_s,
-                  1.days.before.to_date.to_s,
+                  1.day.before.to_date.to_s,
                   issue.closed_on.to_date.to_s], labels
   end
 
@@ -111,7 +111,7 @@ class VersionsHelperPatchTest < Redmine::HelperTest
     # assert labels for xaxis
     assert_equal [3.days.before.to_date.to_s,
                   2.days.before.to_date.to_s,
-                  1.days.before.to_date.to_s,
+                  1.day.before.to_date.to_s,
                   User.current.today.to_s], labels
 
     # assert label in datasets

--- a/test/system/burndown_chart_test.rb
+++ b/test/system/burndown_chart_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../../../../test/application_system_test_case', __FILE__)
+
+class BurndownChartTest < ApplicationSystemTestCase
+  fixtures :projects, :enabled_modules, :versions,
+           :users, :members, :roles, :member_roles,
+           :trackers, :projects_trackers, :enumerations, :issue_statuses, :issues
+
+
+  def test_render_chart_on_version_detail
+    log_user('jsmith', 'jsmith')
+    visit '/versions/2'
+
+    assert page.has_css?('#version-detail-chart')
+    within '#version-detail-chart' do
+      assert page.find('#burndown-chart')
+    end
+  end
+
+  def test_does_not_render_chart_if_issues_empty
+    version = Version.find(2)
+    version.fixed_issues.delete_all
+
+    log_user('jsmith', 'jsmith')
+    visit '/versions/2'
+
+    assert page.has_no_css?('#version-detail-chart')
+    assert page.all(:css, '#version-detail-chart').empty?
+  end
+end

--- a/test/system/burndown_chart_test.rb
+++ b/test/system/burndown_chart_test.rb
@@ -8,23 +8,37 @@ class BurndownChartTest < ApplicationSystemTestCase
            :trackers, :projects_trackers, :enumerations, :issue_statuses, :issues
 
   def test_render_chart_on_version_detail
-    log_user('jsmith', 'jsmith')
-    visit '/versions/2'
+    with_settings :plugin_redmica_ui_extension => {'burndown_chart' => {'enabled' => 1}} do
+      log_user('jsmith', 'jsmith')
+      visit '/versions/2'
 
-    assert page.has_css?('#version-detail-chart')
-    within '#version-detail-chart' do
-      assert page.find('#burndown-chart')
+      assert page.has_css?('#version-detail-chart')
+      within '#version-detail-chart' do
+        assert page.find('#burndown-chart')
+      end
     end
   end
 
   def test_does_not_render_chart_if_issues_empty
-    version = Version.find(2)
-    version.fixed_issues.delete_all
+    with_settings :plugin_redmica_ui_extension => {'burndown_chart' => {'enabled' => 1}} do
+      version = Version.find(2)
+      version.fixed_issues.delete_all
 
-    log_user('jsmith', 'jsmith')
-    visit '/versions/2'
+      log_user('jsmith', 'jsmith')
+      visit '/versions/2'
 
-    assert page.has_no_css?('#version-detail-chart')
-    assert page.all(:css, '#version-detail-chart').empty?
+      assert page.has_no_css?('#version-detail-chart')
+      assert page.all(:css, '#version-detail-chart').empty?
+    end
+  end
+
+  def test_does_not_render_chart_if_setting_enabled_is_nil
+    with_settings :plugin_redmica_ui_extension => {'burndown_chart' => {'enabled' => nil}} do
+      log_user('jsmith', 'jsmith')
+      visit '/versions/2'
+
+      assert page.has_no_css?('#version-detail-chart')
+      assert page.all(:css, '#version-detail-chart').empty?
+    end
   end
 end

--- a/test/system/burndown_chart_test.rb
+++ b/test/system/burndown_chart_test.rb
@@ -7,7 +7,6 @@ class BurndownChartTest < ApplicationSystemTestCase
            :users, :members, :roles, :member_roles,
            :trackers, :projects_trackers, :enumerations, :issue_statuses, :issues
 
-
   def test_render_chart_on_version_detail
     log_user('jsmith', 'jsmith')
     visit '/versions/2'


### PR DESCRIPTION
I propose a feature to visualize the changes of Open / Close issues in the version detail using 'Burndown chart'.
![image](https://user-images.githubusercontent.com/926014/110740871-129e1080-8277-11eb-9073-db3b9c967105.png)