### PR TITLE
Make it possible to hide ideal line when due_date earlier than start_date

### DIFF
--- a/lib/burndown_chart/versions_helper_patch.rb
+++ b/lib/burndown_chart/versions_helper_patch.rb
@@ -40,7 +40,7 @@ module BurndownChart
 
         labels = chart_start_date.step(chart_end_date, step_size).collect{ |d| d.to_s }
         datasets = []
-        if version.due_date
+        if version.due_date && version.due_date > chart_start_date
           datasets << {:label => I18n.t('redmica_ui_extension.burndown_chart.label_ideal_line'), :data => ideal,
                        :backgroundColor => "rgba(0, 0, 0, 0)",
                        :lineTension => 0, :borderWidth => 2, :borderDash => [5, 2], :spanGaps => true}

--- a/test/helpers/versions_helper_patch_test.rb
+++ b/test/helpers/versions_helper_patch_test.rb
@@ -133,6 +133,25 @@ class VersionsHelperPatchTest < Redmine::HelperTest
                   User.current.today.to_s], labels
 
     # assert label in datasets
+    assert_equal 2, datasets.size
+    assert_equal I18n.t('redmica_ui_extension.burndown_chart.label_total_substract_closed_line'), datasets.first[:label]
+    assert_equal I18n.t('redmica_ui_extension.burndown_chart.label_open_line'), datasets.last[:label]
+  end
+
+  def test_issues_burndown_chart_data_should_return_chart_data_without_ideal_when_due_date_earlier_than_start_date
+    version = Version.find(2)
+    version.update(:due_date => 2.days.before.to_date)
+    version.stubs(:start_date).returns(1.days.before.to_date)
+
+    issue = version.fixed_issues.last
+    issue.status = IssueStatus.where(:is_closed => true).first
+    issue.save
+
+    chart_data = issues_burndown_chart_data(version)
+    datasets = chart_data[:datasets]
+
+    # assert label in datasets
+    assert_equal 2, datasets.size
     assert_equal I18n.t('redmica_ui_extension.burndown_chart.label_total_substract_closed_line'), datasets.first[:label]
     assert_equal I18n.t('redmica_ui_extension.burndown_chart.label_open_line'), datasets.last[:label]
   end


### PR DESCRIPTION
バージョンの「期限」が「開始日」よりも早いとideal線が以下のようにプロットされる。
![image](https://user-images.githubusercontent.com/926014/114344195-577cd600-9b9a-11eb-96f0-92e2f182a2ae.png)

「期限」が「開始日」よりも早い場合は、以下のようにideal線をプロットしないよう変更してはどうでしょうか？
![image](https://user-images.githubusercontent.com/926014/114344419-bf332100-9b9a-11eb-8bb3-7f28758cecc3.png)

