### PR TITLE
Change to auto skip the Y-axis ticks

### DIFF
--- a/assets/burndown_chart/javascripts/burndown_chart.js
+++ b/assets/burndown_chart/javascripts/burndown_chart.js
@@ -24,7 +24,7 @@ function renderChart(canvas_id, title, y_label, y_lim, chartData){
         yAxes: [{
           scaleLabel: { display: true, labelString: y_label },
           gridLines: { borderDash: [6, 4] },
-          ticks: { min: 0, max: y_lim, stepSize: 1 }
+          ticks: { min: 0, max: y_lim, autoSkip: true }
         }]
       }
     }

--- a/assets/burndown_chart/javascripts/burndown_chart.js
+++ b/assets/burndown_chart/javascripts/burndown_chart.js
@@ -24,7 +24,7 @@ function renderChart(canvas_id, title, y_label, y_lim, chartData){
         yAxes: [{
           scaleLabel: { display: true, labelString: y_label },
           gridLines: { borderDash: [6, 4] },
-          ticks: { min: 0, max: y_lim, autoSkip: true }
+          ticks: { min: 0, max: y_lim, stepSize: 1, autoSkip: true }
         }]
       }
     }


### PR DESCRIPTION
チケット数が60件弱を超えると、以下のようにY軸の目盛りが重なり合ってしまう。

![image](https://user-images.githubusercontent.com/926014/114973728-fe73b180-9ebb-11eb-9e25-1f8b580cf3cb.png)

Chart.jsで指定できるパラメータ **autoSkip** を **true** に変更することで、Y軸の目盛りが重なり合う現象を回避します。

```diff
-          ticks: { min: 0, max: y_lim, stepSize: 1 }
+          ticks: { min: 0, max: y_lim, stepSize: 1, autoSkip: true }
```
変更後は以下のようにチャートのY軸が重なり合わないようになります。

![image](https://user-images.githubusercontent.com/926014/114974434-57901500-9ebd-11eb-9033-d65240978f0b.png)
