### PR TITLE
Enable to switch Y-axis 'autoSkip' or 'stepSize' depending on the data size

### DIFF
--- a/app/views/ui_extension/_burndown_chart.html.erb
+++ b/app/views/ui_extension/_burndown_chart.html.erb
@@ -1,5 +1,5 @@
 <% if Setting.plugin_redmica_ui_extension['burndown_chart'].to_h['enabled'] && version && chart_data = issues_burndown_chart_data(version) %>
-  <div id="version-detail-chart"><canvas id="burndown-chart"></canvas></div>'
+  <div id="version-detail-chart"><canvas id="burndown-chart"></canvas></div>
   <%= stylesheet_link_tag('../burndown_chart/stylesheets/burndown_chart.css', plugin: 'redmica_ui_extension') %>
   <%= javascript_include_tag('Chart.bundle.min') %>
   <%= javascript_include_tag('../burndown_chart/javascripts/burndown_chart.js', plugin: 'redmica_ui_extension') %>

--- a/assets/burndown_chart/javascripts/burndown_chart.js
+++ b/assets/burndown_chart/javascripts/burndown_chart.js
@@ -10,6 +10,7 @@ function renderChart(canvas_id, title, y_label, y_lim, chartData){
     data: chartData,
     options: {
       responsive: true,
+      maintainAspectRatio: false,
       legend: {
         position: 'right',
         labels: { boxWidth: 20, fontSize: 10, padding: 10 }

--- a/assets/burndown_chart/javascripts/burndown_chart.js
+++ b/assets/burndown_chart/javascripts/burndown_chart.js
@@ -1,4 +1,10 @@
 function renderChart(canvas_id, title, y_label, y_lim, chartData){
+  y_axes_ticks = { min: 0, max: y_lim };
+  if (y_lim > 35) {
+    y_axes_ticks['autoSkip'] = true;
+  } else {
+    y_axes_ticks['stepSize'] = 1;
+  }
   new Chart($(canvas_id), {
     type: 'line',
     data: chartData,
@@ -24,7 +30,7 @@ function renderChart(canvas_id, title, y_label, y_lim, chartData){
         yAxes: [{
           scaleLabel: { display: true, labelString: y_label },
           gridLines: { borderDash: [6, 4] },
-          ticks: { min: 0, max: y_lim, stepSize: 1, autoSkip: true }
+          ticks: y_axes_ticks
         }]
       }
     }

--- a/assets/burndown_chart/javascripts/burndown_chart.js
+++ b/assets/burndown_chart/javascripts/burndown_chart.js
@@ -12,7 +12,7 @@ function renderChart(canvas_id, title, y_label, y_lim, chartData){
       responsive: true,
       maintainAspectRatio: false,
       legend: {
-        position: 'right',
+        position: 'top',
         labels: { boxWidth: 20, fontSize: 10, padding: 10 }
       },
       title: { display: true, text: title },

--- a/assets/burndown_chart/stylesheets/burndown_chart.css
+++ b/assets/burndown_chart/stylesheets/burndown_chart.css
@@ -1,5 +1,5 @@
-body.controller-versions.action-show #version-detail-chart { width: 70%; margin: 2em 0 }
+body.controller-versions.action-show #version-detail-chart { width: 70%; min-height: 500px; margin: 2em 0 }
 @media screen and (max-width: 899px)
 {
-  body.controller-versions.action-show #version-detail-chart {width:100%;}
+  body.controller-versions.action-show #version-detail-chart { width:100%; min-height: 500px }
 }


### PR DESCRIPTION
https://github.com/redmica/redmica_ui_extension/pull/9 の変更により `autoSkip: true` が優先されることによって
チケット数が少ない場合に以下のようにY軸に不要な目盛り（.5）が表示される。
![image](https://user-images.githubusercontent.com/926014/115321655-3c741c80-a1bf-11eb-9db8-36468cbc0a08.png)

チャートにプロットするデータサイズに応じて、`autoSkip: true` と `stepSize: 1` を切り替えるよう変更します。