### PR TITLE
Change the default enabled setting value to true

### DIFF
--- a/app/views/settings/_redmica_ui_extension.html.erb
+++ b/app/views/settings/_redmica_ui_extension.html.erb
@@ -1,8 +1,10 @@
 <p>
   <%= label_tag('settings[searchable_selectbox][enabled]', I18n.t('redmica_ui_extension.searchable_selectbox.label_enable')) %>
-  <%= check_box_tag('settings[searchable_selectbox][enabled]', 1, settings['searchable_selectbox'].to_h['enabled']) %>
+  <%= hidden_field_tag 'settings[searchable_selectbox][enabled]', 0 %>
+  <%= check_box_tag('settings[searchable_selectbox][enabled]', 1, Setting.enabled_redmica_ui_extension_feature?('searchable_selectbox')) %>
 </p>
 <p>
   <%= label_tag('settings[burndown_chart][enabled]', I18n.t('redmica_ui_extension.burndown_chart.label_enable')) %>
-  <%= check_box_tag('settings[burndown_chart][enabled]', 1, settings['burndown_chart'].to_h['enabled']) %>
+  <%= hidden_field_tag 'settings[burndown_chart][enabled]', 0 %>
+  <%= check_box_tag('settings[burndown_chart][enabled]', 1, Setting.enabled_redmica_ui_extension_feature?('burndown_chart')) %>
 </p>

--- a/app/views/ui_extension/_burndown_chart.html.erb
+++ b/app/views/ui_extension/_burndown_chart.html.erb
@@ -1,4 +1,4 @@
-<% if Setting.plugin_redmica_ui_extension['burndown_chart'].to_h['enabled'] && version && chart_data = issues_burndown_chart_data(version) %>
+<% if Setting.enabled_redmica_ui_extension_feature?('burndown_chart') && version && chart_data = issues_burndown_chart_data(version) %>
   <div id="version-detail-chart"><canvas id="burndown-chart"></canvas></div>'
   <%= stylesheet_link_tag('../burndown_chart/stylesheets/burndown_chart.css', plugin: 'redmica_ui_extension') %>
   <%= javascript_include_tag('Chart.bundle.min') %>

--- a/init_redmica_ui_extension.rb
+++ b/init_redmica_ui_extension.rb
@@ -13,3 +13,9 @@ require_dependency 'burndown_chart/versions_helper_patch'
 Rails.configuration.to_prepare do
   VersionsHelper.include BurndownChart::VersionsHelperPatch
 end
+
+# Common methods for redmica_ui_extension
+require_dependency 'redmica_ui_extension/setting_patch'
+Rails.configuration.to_prepare do
+  Setting.include RedmicaUiExtension::SettingPatch
+end

--- a/lib/redmica_ui_extension/setting_patch.rb
+++ b/lib/redmica_ui_extension/setting_patch.rb
@@ -1,0 +1,14 @@
+module RedmicaUiExtension
+  module SettingPatch
+    def self.included(base)
+      base.send(:extend, ClassMethods)
+    end
+
+    module ClassMethods
+      def enabled_redmica_ui_extension_feature?(feature_name)
+        is_enabled = Setting.plugin_redmica_ui_extension[feature_name].to_h['enabled']
+        is_enabled.nil? ? true : is_enabled.to_i == 1
+      end
+    end
+  end
+end

--- a/lib/searchable_selectbox/hook_listener.rb
+++ b/lib/searchable_selectbox/hook_listener.rb
@@ -3,7 +3,7 @@
 module SearchableSelectbox
   class HookListener < Redmine::Hook::ViewListener
     def view_layouts_base_html_head(context)
-      return '' unless Setting.plugin_redmica_ui_extension['searchable_selectbox'].to_h['enabled']
+      return '' unless Setting.enabled_redmica_ui_extension_feature?('searchable_selectbox')
 
       stylesheet_link_tag('../searchable_selectbox/stylesheets/select2.min', plugin: 'redmica_ui_extension') +
       stylesheet_link_tag('../searchable_selectbox/stylesheets/searchable_selectbox', plugin: 'redmica_ui_extension') +

--- a/test/system/burndown_chart_test.rb
+++ b/test/system/burndown_chart_test.rb
@@ -33,7 +33,7 @@ class BurndownChartTest < ApplicationSystemTestCase
   end
 
   def test_does_not_render_chart_if_setting_enabled_is_nil
-    with_settings :plugin_redmica_ui_extension => {'burndown_chart' => {'enabled' => nil}} do
+    with_settings :plugin_redmica_ui_extension => {'burndown_chart' => {'enabled' => 0}} do
       log_user('jsmith', 'jsmith')
       visit '/versions/2'
 

--- a/test/system/burndown_chart_test.rb
+++ b/test/system/burndown_chart_test.rb
@@ -32,7 +32,7 @@ class BurndownChartTest < ApplicationSystemTestCase
     end
   end
 
-  def test_does_not_render_chart_if_setting_enabled_is_nil
+  def test_does_not_render_chart_if_enabled_setting_value_is_zero
     with_settings :plugin_redmica_ui_extension => {'burndown_chart' => {'enabled' => 0}} do
       log_user('jsmith', 'jsmith')
       visit '/versions/2'

--- a/test/system/searchable_selectbox_test.rb
+++ b/test/system/searchable_selectbox_test.rb
@@ -9,7 +9,7 @@ class SearchableSelectboxTest < ApplicationSystemTestCase
            :watchers, :journals, :journal_details
 
   def test_select2_does_not_apply_if_searchable_selectbox_enabled_is_nil
-    with_settings :plugin_redmica_ui_extension => {'searchable_selectbox' => {'enabled' => nil}} do
+    with_settings :plugin_redmica_ui_extension => {'searchable_selectbox' => {'enabled' => 0}} do
       log_user('jsmith', 'jsmith')
       visit '/my/page'
 

--- a/test/system/searchable_selectbox_test.rb
+++ b/test/system/searchable_selectbox_test.rb
@@ -8,7 +8,7 @@ class SearchableSelectboxTest < ApplicationSystemTestCase
            :enumerations, :custom_fields, :custom_values, :custom_fields_trackers,
            :watchers, :journals, :journal_details
 
-  def test_select2_does_not_apply_if_searchable_selectbox_enabled_is_nil
+  def test_select2_does_not_apply_if_searchable_selectbox_enabled_setting_value_is_zero
     with_settings :plugin_redmica_ui_extension => {'searchable_selectbox' => {'enabled' => 0}} do
       log_user('jsmith', 'jsmith')
       visit '/my/page'

--- a/test/unit/setting_patch_test.rb
+++ b/test/unit/setting_patch_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../../../../test/test_helper', __FILE__)
+
+class SettingPatchTest < Redmine::HelperTest
+  fixtures :users
+
+  def test_enabled_redmica_ui_extension_feature?
+    # setting is blank => true
+    with_settings :plugin_redmica_ui_extension => {} do
+      assert Setting.enabled_redmica_ui_extension_feature?('burndown_chart')
+    end
+    # enabled: '1' => true
+    with_settings :plugin_redmica_ui_extension => {'burndown_chart' => {'enabled' => '1'}} do
+      assert Setting.enabled_redmica_ui_extension_feature?('burndown_chart')
+    end
+    # enabled: '0' => false
+    with_settings :plugin_redmica_ui_extension => {'burndown_chart' => {'enabled' => '0'}} do
+      assert_not Setting.enabled_redmica_ui_extension_feature?('burndown_chart')
+    end
+  end
+end


### PR DESCRIPTION
背景:

既存の仕組みではinit.rbで `settings default: {'searchable_selectbox' => {'enabled' => 1}, 'burndown_chart' => {'enabled' => 1}}` と書いていてデフォルトが有効状態になっているように見えますが、  
これはSettingレコードが無いときに入れる値なので、すでに利用を始めた状態で新しく機能を追加した場合はここに `'new_feature' => {'enabled' => 1}`と書いていても何もデータベースに入りません。  
設定がない場合は有効扱いしてほしいという要望があがったため、対応。

----

設定がない場合は有効扱いするために、値が存在したら有効という現在の判定を
* 値がnilだったら有効
* 値が1だったら有効
* 値が0だったら無効

のように変更しました。  
また、現在は無効設定にしたとき値がnilになるため、hidden_tagを足すことでチェックを外したときに0が入るように変更しています。

(今後はデフォルト無効にしたい機能が出てくるかもしれませんが、現時点ではデフォルトで有効にしたくないような機能を入れる予定が無いためこのような実装にしています。必要になったら直します。)

----

レビュワーには @yui-har さんと @takenory さんを指定していますが、お二人のうちお一人に見ていただいたらマージしようかなと思っています。