### PR TITLE
Fix lock_version error on test

### DIFF
--- a/test/helpers/versions_helper_patch_test.rb
+++ b/test/helpers/versions_helper_patch_test.rb
@@ -34,6 +34,7 @@ class VersionsHelperPatchTest < Redmine::HelperTest
     travel_back
 
     # today
+    issue.reload
     issue.status = IssueStatus.where(:is_closed => true).first
     issue.save
 
@@ -82,6 +83,7 @@ class VersionsHelperPatchTest < Redmine::HelperTest
     travel_back
 
     # today (close issue and close version)
+    issue.reload
     issue.status = IssueStatus.where(:is_closed => true).first
     issue.save
     version.status = 'closed'


### PR DESCRIPTION
RedMicaのmasterブランチ（Rails6）でテストが失敗する問題の改善です。
テストに使用するIssueを作成したオブジェクトとDBに登録後のlock_versionが異なるため
テストデータの更新時にエラーとなり、テストが失敗していました。

対象のIssueオブジェクトをリロードすることで対処しています。