### PR TITLE
Add issues fixtures to VersionsHelperPatchTest

### DIFF
--- a/test/helpers/versions_helper_patch_test.rb
+++ b/test/helpers/versions_helper_patch_test.rb
@@ -4,7 +4,7 @@ require File.expand_path('../../../../../test/test_helper', __FILE__)
 
 class VersionsHelperPatchTest < Redmine::HelperTest
   include VersionsHelper
-  fixtures :projects, :enabled_modules, :versions,
+  fixtures :projects, :enabled_modules, :versions, :issues,
            :users, :members, :roles, :member_roles,
            :trackers, :projects_trackers, :enumerations, :issue_statuses
 


### PR DESCRIPTION


Github Actionsで実行したテストが次のように失敗していました。 (https://github.com/ishikawa999/redmica_ui_extension/runs/2405924893?check_suite_focus=true)
```
  RAILS_ENV=test bundle exec rake test TEST=plugins/redmica_ui_extension/test
  shell: sh -e {0}
Run options: --seed 63846

# Running:

.E

Error:
VersionsHelperPatchTest#test_issues_burndown_chart_data_should_return_chart_data_without_ideal_when_due_date_earlier_than_start_date:
NoMethodError: undefined method `status=' for nil:NilClass
    plugins/redmica_ui_extension/test/helpers/versions_helper_patch_test.rb:149:in `test_issues_burndown_chart_data_should_return_chart_data_without_ideal_when_due_date_earlier_than_start_date'

bin/rails test plugins/redmica_ui_extension/test/helpers/versions_helper_patch_test.rb:143

.E

Error:
VersionsHelperPatchTest#test_issues_burndown_chart_data_should_return_chart_data_without_ideal:
NoMethodError: undefined method `[]' for nil:NilClass
    plugins/redmica_ui_extension/test/helpers/versions_helper_patch_test.rb:128:in `test_issues_burndown_chart_data_should_return_chart_data_without_ideal'

bin/rails test plugins/redmica_ui_extension/test/helpers/versions_helper_patch_test.rb:122

...Capybara starting Puma...
* Version 5.2.2 , codename: Fettisdagsbulle
* Min threads: 0, max threads: 4
* Listening on http://172.18.0.2:3000
........

Finished in 22.672664s, 0.6616 runs/s, 2.0730 assertions/s.
15 runs, 47 assertions, 0 failures, 2 errors, 0 skips
```

VersionsHelperPatchTestでfixtures: :issuesが読み込まれていないことで、`version.fixed_issues.last`がnilになっているようです。
fixtures: :issuesを追加したので、念のため確認をお願いいたします。(ご確認いただけましたら私がマージします。)

https://github.com/ishikawa999/redmica_ui_extension/actions/runs/772643347 (これと同様の変更を行った後のテストがすべて成功している様子)