### PR TITLE
Add GitHub actions configration

### DIFF
--- a/.github/scripts/setup-redmica.sh
+++ b/.github/scripts/setup-redmica.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+redmica_branch=$1
+database=$2
+redmine_dir=$3
+
+cd $redmine_dir
+
+# Replace RedMica code to master branch code
+# TODO: これで入れ替えて動かなくなったら独自でDockerfileを書く
+if [ $redmica_branch = 'master' ]; then
+  set +e
+  rm -rf ./* > /dev/null
+  rm -rf ./.* 2> /dev/null
+  wget --no-check-certificate https://github.com/redmica/redmica/archive/master.tar.gz
+  tar -xf master.tar.gz --strip-components=1
+  set -e
+fi
+
+cp -r $GITHUB_WORKSPACE ./plugins
+cp ./plugins/redmica_ui_extension/.github/templates/database-$database.yml config/database.yml
+cp ./plugins/redmica_ui_extension/.github/templates/application_system_test_case.rb test/application_system_test_case.rb
+
+# PDFのサムネイル作成テストを成功させるため
+sed -i 's/^.*policy.*coder.*none.*PDF.*//' /etc/ImageMagick-6/policy.xml
+
+# DB側のログを表示しないため(additional_environment.rbでログを標準出力に出している)
+rm -f ./config/additional_environment.rb
+
+apt update
+apt install -y build-essential
+bundle install --with test
+bundle update
+bundle exec rake db:create db:migrate RAILS_ENV=test
+
+# 利用しているRedmineのバージョンなどを確認
+RAILS_ENV=test ruby bin/about

--- a/.github/scripts/setup-redmica.sh
+++ b/.github/scripts/setup-redmica.sh
@@ -13,7 +13,7 @@ if [ $redmica_branch = 'master' ]; then
   rm -rf ./* > /dev/null
   rm -rf ./.* 2> /dev/null
   wget --no-check-certificate https://github.com/redmica/redmica/archive/master.tar.gz
-  tar -xf master.tar.gz --strip-components=1
+  tar -xzf master.tar.gz --strip-components=1
   set -e
 fi
 

--- a/.github/templates/application_system_test_case.rb
+++ b/.github/templates/application_system_test_case.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+# Redmine - project management software
+# Copyright (C) 2006-2021  Jean-Philippe Lang
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+require File.expand_path('../test_helper', __FILE__)
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  DOWNLOADS_PATH = File.expand_path(File.join(Rails.root, 'tmp', 'downloads'))
+  GOOGLE_CHROME_OPTS_ARGS = []
+
+  # Allow running Capybara default server on custom IP address and/or port
+  Capybara.server_host = ENV['CAPYBARA_SERVER_HOST'] if ENV['CAPYBARA_SERVER_HOST']
+  Capybara.server_port = ENV['CAPYBARA_SERVER_PORT'] if ENV['CAPYBARA_SERVER_PORT']
+
+  # Allow defining Google Chrome options arguments based on a comma-delimited string environment variable
+  GOOGLE_CHROME_OPTS_ARGS = ENV['GOOGLE_CHROME_OPTS_ARGS'].split(",") if ENV['GOOGLE_CHROME_OPTS_ARGS']
+
+  options = {}
+  # Allow running tests using a remote Selenium hub
+  options[:url] = ENV['SELENIUM_REMOTE_URL'] if ENV['SELENIUM_REMOTE_URL']
+  options[:desired_capabilities] = Selenium::WebDriver::Remote::Capabilities.chrome(
+                  'goog:chromeOptions' => {
+                    'args' => GOOGLE_CHROME_OPTS_ARGS,
+                    'prefs' => {
+                      'download.default_directory' => DOWNLOADS_PATH.gsub(File::SEPARATOR, File::ALT_SEPARATOR || File::SEPARATOR),
+                      'download.prompt_for_download' => false,
+                      'plugins.plugins_disabled' => ["Chrome PDF Viewer"]
+                    }
+                  }
+                )
+  options[:browser] = :remote
+  options[:url] = "http://chrome:4444/wd/hub"
+  Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
+  Capybara.server_port = 3000
+  driven_by(
+    :selenium, using: :chrome, screen_size: [1024, 900],
+    options: options
+  )
+
+  setup do
+    Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
+    # Allow defining a custom app host (useful when using a remote Selenium hub)
+    if ENV['CAPYBARA_APP_HOST']
+      Capybara.configure do |config|
+        config.app_host = ENV['CAPYBARA_APP_HOST']
+      end
+    end
+
+    clear_downloaded_files
+    Setting.delete_all
+    Setting.clear_cache
+  end
+
+  teardown do
+    Setting.delete_all
+    Setting.clear_cache
+  end
+
+  # Should not depend on locale since Redmine displays login page
+  # using default browser locale which depend on system locale for "real" browsers drivers
+  def log_user(login, password)
+    visit '/my/page'
+    assert_equal '/login', current_path
+    within('#login-form form') do
+      fill_in 'username', :with => login
+      fill_in 'password', :with => password
+      find('input[name=login]').click
+    end
+    assert_equal '/my/page', current_path
+  end
+
+  def clear_downloaded_files
+    FileUtils.rm downloaded_files
+  end
+
+  def downloaded_files(filename='*')
+    Dir.glob("#{DOWNLOADS_PATH}/#{filename}").
+      reject{|f| f=~/\.(tmp|crdownload)$/}.sort_by{|f| File.mtime(f)}
+  end
+
+  # Returns the path of the download file
+  def downloaded_file(filename='*')
+    files = []
+    Timeout.timeout(5) do
+      loop do
+        files = downloaded_files(filename)
+        break if files.present?
+
+        sleep 0.2
+      end
+    end
+    files.last
+  end
+end
+
+FileUtils.mkdir_p ApplicationSystemTestCase::DOWNLOADS_PATH

--- a/.github/templates/database-mysql.yml
+++ b/.github/templates/database-mysql.yml
@@ -1,0 +1,11 @@
+default: &default
+  adapter: mysql2
+  encoding: utf8
+  host: db
+  port: 3306
+  username: root
+  password: password
+
+test:
+  <<: *default
+  database: redmine_test

--- a/.github/templates/database-postgres.yml
+++ b/.github/templates/database-postgres.yml
@@ -1,0 +1,11 @@
+default: &default
+  adapter: postgresql
+  encoding: utf8
+  host: db
+  port: 5432
+  username: postgres
+  password: postgres
+
+test:
+  <<: *default
+  database: redmine_test

--- a/.github/templates/database-sqlite.yml
+++ b/.github/templates/database-sqlite.yml
@@ -1,0 +1,9 @@
+default: &default
+  adapter: sqlite3
+  encoding: utf8
+  host: localhost
+  username: redmine
+
+test:
+  <<: *default
+  database: redmine_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,88 @@
+name: Test
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  test-postgres:
+    strategy:
+      fail-fast: false
+      matrix:
+        redmica_branch: [master, released-latest]
+    runs-on: ubuntu-latest
+    container:
+      image: redmica/redmica:latest
+    services:
+      chrome:
+        image: selenium/standalone-chrome-debug:3.141.59-europium
+      db:
+        image: postgres:11
+        env:
+          LANG: C.UTF-8
+          POSTGRES_INITDB_ARGS: --locale=C.UTF-8
+          POSTGRES_PASSWORD: postgres
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    defaults:
+      run:
+        working-directory: /usr/src/redmine
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup
+        run: |
+          chmod +x /__w/redmica_ui_extension/redmica_ui_extension/.github/scripts/setup-redmica.sh
+          /__w/redmica_ui_extension/redmica_ui_extension/.github/scripts/setup-redmica.sh ${{matrix.redmica_branch}} postgres /usr/src/redmine
+      - name: Test RedMica UI Extension plugin
+        run: RAILS_ENV=test bundle exec rake test TEST=plugins/redmica_ui_extension/test
+      - name: Test RedMica
+        run: RAILS_ENV=test bundle exec rake test
+
+  test-mysql:
+    strategy:
+      fail-fast: false
+      matrix:
+        redmica_branch: [master, released-latest]
+    runs-on: ubuntu-latest
+    container:
+      image: redmica/redmica:latest
+    services:
+      chrome:
+        image: selenium/standalone-chrome-debug:3.141.59-europium
+      db:
+        image: mysql:5
+        env:
+          MYSQL_ROOT_PASSWORD: password
+    defaults:
+      run:
+        working-directory: /usr/src/redmine
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup
+        run: |
+          chmod +x /__w/redmica_ui_extension/redmica_ui_extension/.github/scripts/setup-redmica.sh
+          /__w/redmica_ui_extension/redmica_ui_extension/.github/scripts/setup-redmica.sh ${{matrix.redmica_branch}} mysql /usr/src/redmine
+      - name: Test RedMica UI Extension plugin
+        run: RAILS_ENV=test bundle exec rake test TEST=plugins/redmica_ui_extension/test
+      - name: Test RedMica
+        run: RAILS_ENV=test bundle exec rake test
+
+  test-sqlite:
+    strategy:
+      fail-fast: false
+      matrix:
+        redmica_branch: [master, released-latest]
+    runs-on: ubuntu-latest
+    container:
+      image: redmica/redmica:latest
+    services:
+      chrome:
+        image: selenium/standalone-chrome-debug:3.141.59-europium
+    defaults:
+      run:
+        working-directory: /usr/src/redmine
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup
+        run: |
+          chmod +x /__w/redmica_ui_extension/redmica_ui_extension/.github/scripts/setup-redmica.sh
+          /__w/redmica_ui_extension/redmica_ui_extension/.github/scripts/setup-redmica.sh ${{matrix.redmica_branch}} sqlite /usr/src/redmine
+      - name: Test RedMica UI Extension plugin
+        run: RAILS_ENV=test bundle exec rake test TEST=plugins/redmica_ui_extension/test
+      - name: Test RedMica
+        run: RAILS_ENV=test bundle exec rake test


### PR DESCRIPTION
このリポジトリにpushしたとき、forkリポジトリからこのリポジトリに対してプルリクエストを作ったとき、CI実行履歴から手動で再実行を選択したときに
```
RAILS_ENV=test bundle exec rake test TEST=plugins/redmica_ui_extension/test
RAILS_ENV=test bundle exec rake test
```
を実行します。

**テスト対象:**  
RedMica:
* https://github.com/redmica/redmica のmasterブランチ最新のRedMica
* redmica/redmica:latestで動いているリリース済み最新バージョンのRedMica

DB:
* postgres:11
* mysql:5
* sqlite

の各組み合わせごとにテストを実行します。(6パターン)

**これを動かすための環境作りについて説明:**
実行速度を上げるためにRedMicaが動くために必要なライブラリが入っているredmica/redmica:latestイメージの上でテストを実行します。
redmica/redmica:latestにはproductionモードで動くためのdatabase.ymlやgem、ライブラリしか入っていないためsetup_redmica.shで必要なコマンドを実行しています。

また、`masterブランチ最新のRedMica`はredmica/redmica:latestの/usr/src/redmineディレクトリの中身をまるごとGitHubから取得したmasterブランチ最新のコードに置き換えることで動かしています。(かなり強引で、今後上手く動かなくなる可能性あり)
今後動かなくなったらredmica/redmica:latest上でテストするのをやめ、masterブランチ最新のRedMicaのテストができるDockerfile, docker-compose.ymlを書いてそれをGitHub Actionsで実行する形にするつもりです。
最初からそのやり方でも良いですが、書くコードの量が増えたり実行時間が増えたりするので一旦今の簡単な仕組みで実装してしまいたいと思っています。