### PR TITLE
Fix according to the warning when loading files

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require 'redmine'
-require_relative 'init_redmica_ui_extension'
+require File.expand_path('../init_redmica_ui_extension', __FILE__)
 
 Redmine::Plugin.register :redmica_ui_extension do
   requires_redmine version_or_higher: '4.1'

--- a/init_redmica_ui_extension.rb
+++ b/init_redmica_ui_extension.rb
@@ -1,21 +1,17 @@
 # frozen_string_literal: true
 
-# searchable_selectbox
-require_dependency 'searchable_selectbox/hook_listener'
-require_dependency 'searchable_selectbox/my_helper_patch'
-Rails.configuration.to_prepare do
-  MyHelper.include SearchableSelectbox::MyHelperPatch
-end
-
-# burndown_chart
-require_dependency 'burndown_chart/hook_listener'
-require_dependency 'burndown_chart/versions_helper_patch'
-Rails.configuration.to_prepare do
-  VersionsHelper.include BurndownChart::VersionsHelperPatch
-end
-
-# Common methods for redmica_ui_extension
-require_dependency 'redmica_ui_extension/setting_patch'
-Rails.configuration.to_prepare do
+Rails.application.reloader.to_prepare do
+  # Common methods for redmica_ui_extension
+  require 'redmica_ui_extension/setting_patch'
   Setting.include RedmicaUiExtension::SettingPatch
+
+  # searchable_selectbox
+  require 'searchable_selectbox/hook_listener'
+  require 'searchable_selectbox/my_helper_patch'
+  MyHelper.include SearchableSelectbox::MyHelperPatch
+
+  # burndown_chart
+  require 'burndown_chart/hook_listener'
+  require 'burndown_chart/versions_helper_patch'
+  VersionsHelper.include BurndownChart::VersionsHelperPatch
 end


### PR DESCRIPTION
If you run rails s with the plugin installed, you will get the following warning.
I followed the warning and fixed the code.
```
DEPRECATION WARNING: Initialization autoloaded the constants SearchableSelectbox::HookListener, MyHelper, SearchableSelectbox::MyHelperPatch, BurndownChart::HookListener, VersionsHelper, BurndownChart::VersionsHelperPatch, RedmicaUiExtension::SettingPatch
```