### PR TITLE
 Changed to trigger the change event twice only when there is a native change event

### DIFF
--- a/assets/searchable_selectbox/javascripts/searchable_selectbox.js
+++ b/assets/searchable_selectbox/javascripts/searchable_selectbox.js
@@ -17,7 +17,7 @@ EventTarget.prototype._addEventListener = EventTarget.prototype.addEventListener
 EventTarget.prototype.addEventListener = function(type, listener, options) {
    this._addEventListener(type, listener, options);
    // !String(listener).includes('triggered!'): Exclude events triggered by jQuery's trigger function
-   if (type=='change' && this.tagName == 'SELECT' && !String(listener).includes('triggered!')) {
+   if (type.toLowercase === 'change' && this.tagName.toLowercase === 'select' && !String(listener).includes('triggered!')) {
      $(this).attr('data-use-add-change-event-listener', true)
    }
 };

--- a/assets/searchable_selectbox/javascripts/searchable_selectbox.js
+++ b/assets/searchable_selectbox/javascripts/searchable_selectbox.js
@@ -12,6 +12,15 @@ $(document).on('ajax:success', function() {
   initAssignToMeLink();
 });
 
+// Override addEventListener to get that there is a native event.
+EventTarget.prototype._addEventListener = EventTarget.prototype.addEventListener;
+EventTarget.prototype.addEventListener = function(type, listener, options) {
+   this._addEventListener(type, listener, options);
+   if (type=='change' && this.tagName == 'SELECT' && !String(listener).includes('triggered!')) {
+     $(this).attr('data-use-add-change-event-listener', true)
+   }
+};
+
 $(function() {
   // Replace with select2 when loading page.
   replaceSelect2();
@@ -59,16 +68,14 @@ function replaceSelect2() {
       selectInTabular.select2({
         width: 'style'
       }).on('select2:select', function() {
-        // Rails.fire cannot be used in Redmine 3.x or earlier, so it will not be executed.
-        if (typeof Rails != 'undefined') { Rails.fire($(this)[0], 'change') }
+        retriggerChangeIfNativeEventExists($(this));
       });
     }
 
     var other = $('select:not([multiple]):not([data-remote]):not(.select2-hidden-accessible)');
     if (other.length) {
       other.select2().on('select2:select', function() {
-        // Rails.fire cannot be used in Redmine 3.x or earlier, so it will not be executed.
-        if (typeof Rails != 'undefined') { Rails.fire($(this)[0], 'change') }
+        retriggerChangeIfNativeEventExists($(this));
       });
     }
 
@@ -88,4 +95,13 @@ function initAssignToMeLink() {
     $('#issue_assigned_to_id').val(element.data('id')).change();
     element.hide();
   });
+}
+
+// Bug handling: https://github.com/select2/select2/issues/1908
+// Retrigger the change event only when there is a native event.
+function retriggerChangeIfNativeEventExists(element) {
+  // Rails.fire cannot be used in Redmine 3.x or earlier, so it will not be executed.
+  if (element.data('use-add-change-event-listener') && typeof Rails != 'undefined') {
+    Rails.fire(element[0], 'change')
+  }
 }

--- a/assets/searchable_selectbox/javascripts/searchable_selectbox.js
+++ b/assets/searchable_selectbox/javascripts/searchable_selectbox.js
@@ -17,7 +17,7 @@ EventTarget.prototype._addEventListener = EventTarget.prototype.addEventListener
 EventTarget.prototype.addEventListener = function(type, listener, options) {
    this._addEventListener(type, listener, options);
    // !String(listener).includes('triggered!'): Exclude events triggered by jQuery's trigger function
-   if (type.toLowerCase() === 'change' && this.tagName && this.tagName.toLowerCase() === 'select') {
+   if (type.toLowerCase() === 'change' && this.tagName && this.tagName.toLowerCase() === 'select' && !String(listener).includes('triggered!')) {
      $(this).attr('data-use-add-change-event-listener', true)
    }
 };

--- a/assets/searchable_selectbox/javascripts/searchable_selectbox.js
+++ b/assets/searchable_selectbox/javascripts/searchable_selectbox.js
@@ -16,6 +16,7 @@ $(document).on('ajax:success', function() {
 EventTarget.prototype._addEventListener = EventTarget.prototype.addEventListener;
 EventTarget.prototype.addEventListener = function(type, listener, options) {
    this._addEventListener(type, listener, options);
+   // !String(listener).includes('triggered!'): Exclude events triggered by jQuery's trigger function
    if (type=='change' && this.tagName == 'SELECT' && !String(listener).includes('triggered!')) {
      $(this).attr('data-use-add-change-event-listener', true)
    }

--- a/assets/searchable_selectbox/javascripts/searchable_selectbox.js
+++ b/assets/searchable_selectbox/javascripts/searchable_selectbox.js
@@ -17,7 +17,7 @@ EventTarget.prototype._addEventListener = EventTarget.prototype.addEventListener
 EventTarget.prototype.addEventListener = function(type, listener, options) {
    this._addEventListener(type, listener, options);
    // !String(listener).includes('triggered!'): Exclude events triggered by jQuery's trigger function
-   if (type.toLowercase === 'change' && this.tagName.toLowercase === 'select' && !String(listener).includes('triggered!')) {
+   if (type.toLowerCase() === 'change' && this.tagName && this.tagName.toLowerCase() === 'select') {
      $(this).attr('data-use-add-change-event-listener', true)
    }
 };


### PR DESCRIPTION
#17 

問題の内容:
* searchable_selectbox機能が有効になっているとき、セレクトボックスに対するchangeイベントが2回発生する
* changeイベントを2回発生させているのは、https://github.com/redmica/redmica_ui_extension/issues/17#issuecomment-922279390 の問題の回避策(select2で作られた要素に変更を加えたとき、jqueryのchangeイベントは発生してもaddEventListenerで設定したネイティブなイベントが拾えない)
* ただ、issues_templateプラグインの0.3-stableブランチのコードをはじめとして、イベントが2回発生することにより正しく挙動しないケースもある

今回の変更:
根本的な問題の解決は難しいため、ネイティブなイベントが存在するときにのみイベントを2回発生させるように変更します。
これによって、ネイティブなイベントが存在しないときは通常通りの動きになるためイベントが2回発生することによる多くの問題は解決するはずです。

ネイティブなイベントが存在することを取得する方法は関数として提供されていないため、 `EventTarget.prototype.addEventListener` を上書きし、addEventListenerが動いたという情報を追加するdata属性をelementに対して追加するようにしています。

@yui-har レビューをお願いいたします。