### PR TITLE
Use `require_relative` to avoid building an absolute path for `require`

### DIFF
--- a/.github/templates/application_system_test_case.rb
+++ b/.github/templates/application_system_test_case.rb
@@ -17,7 +17,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-require File.expand_path('../test_helper', __FILE__)
+require_relative 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   DOWNLOADS_PATH = File.expand_path(File.join(Rails.root, 'tmp', 'downloads'))

--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../init_redmica_ui_extension', __FILE__)
+require_relative 'init_redmica_ui_extension'
 
 Redmine::Plugin.register :redmica_ui_extension do
   requires_redmine version_or_higher: '4.1'

--- a/test/helpers/application_helper_patch_test.rb
+++ b/test/helpers/application_helper_patch_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../../../../test/test_helper', __FILE__)
+require_relative '../../../../test/test_helper'
 
 class ApplicationHelperPatchTest < Redmine::HelperTest
   include ApplicationHelper

--- a/test/helpers/versions_helper_patch_test.rb
+++ b/test/helpers/versions_helper_patch_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../../../../test/test_helper', __FILE__)
+require_relative '../../../../test/test_helper'
 
 class VersionsHelperPatchTest < Redmine::HelperTest
   include VersionsHelper

--- a/test/system/burndown_chart_test.rb
+++ b/test/system/burndown_chart_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../../../../test/application_system_test_case', __FILE__)
+require_relative '../../../../test/application_system_test_case'
 
 class BurndownChartTest < ApplicationSystemTestCase
   fixtures :projects, :enabled_modules, :versions,

--- a/test/system/mermaid_macro_test.rb
+++ b/test/system/mermaid_macro_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../../../../test/application_system_test_case', __FILE__)
+require_relative '../../../../test/application_system_test_case'
 
 class MermaidMacroTest < ApplicationSystemTestCase
   fixtures :projects, :users, :email_addresses, :roles, :members, :member_roles,

--- a/test/system/searchable_selectbox_test.rb
+++ b/test/system/searchable_selectbox_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../../../../test/application_system_test_case', __FILE__)
+require_relative '../../../../test/application_system_test_case'
 
 class SearchableSelectboxTest < ApplicationSystemTestCase
   fixtures :projects, :users, :email_addresses, :roles, :members, :member_roles,

--- a/test/unit/setting_patch_test.rb
+++ b/test/unit/setting_patch_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../../../../../test/test_helper', __FILE__)
+require_relative '../../../../test/test_helper'
 
 class SettingPatchTest < Redmine::HelperTest
   fixtures :users


### PR DESCRIPTION
This change removes `File.expand_path` and `__FILE__` from the parameter of `require`.

The following is an example.

``` diff
diff --git a/init.rb b/init.rb
index 942a97a..acf43d1 100644
--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../init_redmica_ui_extension', __FILE__)
+require_relative 'init_redmica_ui_extension'
 
 Redmine::Plugin.register :redmica_ui_extension do
   requires_redmine version_or_higher: '4.1'
```