### PR TITLE
Support redmine_issue_templates plugin (Built-In / Custom Fields feature

### DIFF
--- a/assets/searchable_selectbox/javascripts/searchable_selectbox.js
+++ b/assets/searchable_selectbox/javascripts/searchable_selectbox.js
@@ -70,7 +70,12 @@ function replaceSelect2() {
   if ($('body').hasClass('controller-workflows')) {
     return;
   } else {
-    var selectInTabular = $('.tabular .splitcontent select:not([multiple]):not([data-remote]):not(.select2-hidden-accessible)');
+    if ($('#template_area').length) {
+      // This code is for the `Support Built-In / Custom Fields` feature of the redmine_issue_templates plugin.
+      var selectInTabular = $('.tabular .splitcontent select:not([multiple]):not([data-remote])');
+    } else {
+      var selectInTabular = $('.tabular .splitcontent select:not([multiple]):not([data-remote]):not(.select2-hidden-accessible)');
+    }
     if (selectInTabular.length) {
       selectInTabular.select2({
         width: 'style'


### PR DESCRIPTION
問題の再現方法

* redmine_issue_templatesプラグインをインストール (1.0.0以上)
* 管理 > プラグイン > Redmine Issue Templates pluginの設定 で 「標準/カスタムフィールドの利用を可能にする」にチェックを入れ保存
* チケットテンプレートモジュールが有効になったプロジェクトで、「標準/カスタムフィールドの利用を可能にする」機能をつかって担当者(などのセレクトボックスで値を選択するフィールド)の値を上書きするテンプレートを作成する
* チケット新規作成画面で作成したチケットテンプレートを適用すると、担当者のセレクトボックスに上書きされた値が表示されない（セレクトボックスをクリックすると上書きされた値で選択できていることが分かるが、閉じているときの表示に反映されていない）

修正前: テンプレート適用後のセレクトボックス
<img width="474" alt="screenshot 2023-03-14 15 09 20" src="https://user-images.githubusercontent.com/14245262/224922939-d8c2bb87-63df-4135-a053-897a9ea53ba5.png"> 
修正後: テンプレート適用後のセレクトボックス
<img width="474" alt="screenshot 2023-03-14 15 10 00" src="https://user-images.githubusercontent.com/14245262/224922926-812698d9-f3f7-4dc5-ae55-8905b28340e9.png"> 