### PR TITLE
Suppoer Rails 7.1

### DIFF
--- a/init_redmica_ui_extension.rb
+++ b/init_redmica_ui_extension.rb
@@ -35,5 +35,6 @@ Redmine::WikiFormatting::Macros.register do
 end
 
 # preview_attachment
+require File.dirname(__FILE__) + '/lib/preview_attachment/application_helper_patch'
 require File.dirname(__FILE__) + '/lib/preview_attachment/hook_listener'
 ApplicationHelper.include PreviewAttachment::ApplicationHelperPatch


### PR DESCRIPTION
Fixes an issue with the latest Redmine (Rails 7.1.2) where the application fails to start when this plugin is included.

```
=> Booting Puma
=> Rails 7.1.2 application starting in development 
=> Run `bin/rails server --help` for more startup options
Exiting
/var/lib/redmine/plugins/redmica_ui_extension/init_redmica_ui_extension.rb:39:in `<top (required)>': uninitialized constant PreviewAttachment::ApplicationHelperPatch (NameError)

ApplicationHelper.include PreviewAttachment::ApplicationHelperPatch
                                           ^^^^^^^^^^^^^^^^^^^^^^^^
        from /var/lib/redmine/plugins/redmica_ui_extension/init.rb:3:in `require_relative'
        from /var/lib/redmine/plugins/redmica_ui_extension/init.rb:3:in `<top (required)>'
        from /var/lib/redmine/lib/redmine/plugin_loader.rb:31:in `load'
        from /var/lib/redmine/lib/redmine/plugin_loader.rb:31:in `run_initializer'
        from /var/lib/redmine/lib/redmine/plugin_loader.rb:108:in `each'
        from /var/lib/redmine/lib/redmine/plugin_loader.rb:108:in `block in load'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:448:in `instance_exec'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:448:in `block in make_lambda'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:202:in `block (2 levels) in halting'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:707:in `block (2 levels) in default_terminator'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:706:in `catch'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:706:in `block in default_terminator'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:203:in `block in halting'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:598:in `block in invoke_before'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:598:in `each'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:598:in `invoke_before'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:109:in `run_callbacks'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/reloader.rb:96:in `prepare!'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/application/finisher.rb:74:in `block in <module:Finisher>'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/initializable.rb:32:in `instance_exec'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/initializable.rb:32:in `run'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/initializable.rb:61:in `block in run_initializers'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:228:in `block in tsort_each'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:431:in `each_strongly_connected_component_from'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:349:in `block in each_strongly_connected_component'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:347:in `each'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:347:in `call'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:347:in `each_strongly_connected_component'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:226:in `tsort_each'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:205:in `tsort_each'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/initializable.rb:60:in `run_initializers'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/application.rb:423:in `initialize!'
        from /var/lib/redmine/config/environment.rb:16:in `<top (required)>'
        from config.ru:3:in `require_relative'
        from config.ru:3:in `block in <main>'
        from /usr/local/bundle/gems/rack-3.0.8/lib/rack/builder.rb:103:in `eval'
        from /usr/local/bundle/gems/rack-3.0.8/lib/rack/builder.rb:103:in `new_from_string'
        from /usr/local/bundle/gems/rack-3.0.8/lib/rack/builder.rb:94:in `load_file'
        from /usr/local/bundle/gems/rack-3.0.8/lib/rack/builder.rb:64:in `parse_file'
        from /usr/local/bundle/gems/rackup-2.1.0/lib/rackup/server.rb:354:in `build_app_and_options_from_config'
        from /usr/local/bundle/gems/rackup-2.1.0/lib/rackup/server.rb:263:in `app'
        from /usr/local/bundle/gems/rackup-2.1.0/lib/rackup/server.rb:424:in `wrapped_app'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/commands/server/server_command.rb:76:in `log_to_stdout'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/commands/server/server_command.rb:36:in `start'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/commands/server/server_command.rb:145:in `block in perform'
        from <internal:kernel>:90:in `tap'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/commands/server/server_command.rb:136:in `perform'
        from /usr/local/bundle/gems/thor-1.3.0/lib/thor/command.rb:28:in `run'
        from /usr/local/bundle/gems/thor-1.3.0/lib/thor/invocation.rb:127:in `invoke_command'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/command/base.rb:178:in `invoke_command'
        from /usr/local/bundle/gems/thor-1.3.0/lib/thor.rb:527:in `dispatch'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/command/base.rb:73:in `perform'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/command.rb:71:in `block in invoke'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/command.rb:149:in `with_argv'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/command.rb:69:in `invoke'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/commands.rb:18:in `<top (required)>'
        from bin/rails:4:in `require'
        from bin/rails:4:in `<main>'
```