### PR TITLE
Remove magnifier icon in select2 search field

### DIFF
--- a/assets/stylesheets/searchable_selectbox/searchable_selectbox.css
+++ b/assets/stylesheets/searchable_selectbox/searchable_selectbox.css
@@ -69,10 +69,6 @@ fieldset#filters td.values .select2-container--default {
 }
 
 /* Change the style referring to the default theme of Redmine */
-.select2-search--dropdown input.select2-search__field {
-  background: #fff url(../../../../images/magnifier.png) no-repeat 2px 50%;
-  padding-left: 20px;
-}
 .select2-search--dropdown input.select2-search__field:focus {
   border: 1px solid #5ad;
   outline: none;


### PR DESCRIPTION
Due to the impact of Propshaft support, there is an issue in RedMica 3.0 where the magnifying glass icon does not appear when the searchable select box feature is enabled.
I have decided to remove the magnifying glass icon since it is still clear that the select box is searchable without it.

Additionally, for the Bleuclair theme, the magnifying glass icon and padding are added on the theme side, so the display remains unchanged.

|selectbox before changes|selectbox after changes|selectbox after changes(with bleuclair theme)|
|----|---|---|
|<img width="382" alt="screenshot 2024-07-04 16 29 03" src="https://github.com/redmica/redmica_ui_extension/assets/14245262/0dab41ed-7b1d-463d-b8d6-bc419d82dde2">|<img width="382" alt="screenshot 2024-07-04 16 28 05" src="https://github.com/redmica/redmica_ui_extension/assets/14245262/f27abde1-3ebe-414a-a392-a6f324e61287">|<img width="382" alt="screenshot 2024-07-04 16 28 26" src="https://github.com/redmica/redmica_ui_extension/assets/14245262/94e022d4-b5b2-4af8-8db0-c7ad0557bde4">|