### PR TITLE
Fix small height of empty option in searchable select boxes

### DIFF
--- a/assets/stylesheets/searchable_selectbox/searchable_selectbox.css
+++ b/assets/stylesheets/searchable_selectbox/searchable_selectbox.css
@@ -64,6 +64,9 @@ fieldset#filters td.values .select2-container--default {
 }
 
 /* Increase the height of the select box */
+.select2-results__options li:empty::before {
+  content: "\00a0";
+}
 .select2-container--default .select2-results>.select2-results__options{
   max-height: 450px;
 }


### PR DESCRIPTION
<img width="405" alt="screenshot 2024-07-05 9 36 42" src="https://github.com/redmica/redmica_ui_extension/assets/14245262/6a9db422-ef50-4049-8459-aedeef066f3f">

Fixes an issue where the height of the empty option is reduced, as shown in the image.
This problem was probably caused by https://www.redmine.org/issues/40210.