### PR TITLE
Test against RedMica 3.0.1 and Ruby 3.3

### DIFF
--- a/.github/scripts/setup-redmica.sh
+++ b/.github/scripts/setup-redmica.sh
@@ -55,6 +55,11 @@ sed -i 's/^.*policy.*coder.*none.*PDF.*//' /etc/ImageMagick-6/policy.xml
 # DB側のログを表示しないため(additional_environment.rbでログを標準出力に出している)
 rm -f ./config/additional_environment.rb
 
+# Temporary workaround to avoid test failures due to the change
+# from unprocessable_entity to unprocessable_content in Rack 3.1.0.
+# https://github.com/rack/rack/pull/2137
+echo "gem 'rack', '< 3.1.0'" >> Gemfile.local
+
 bundle install --with test development
 bundle update
 bundle exec rake db:create db:migrate RAILS_ENV=test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmica_version: ["v2.4.0", "master"]
+        redmica_version: ["v3.0.1", "master"]
     runs-on: ubuntu-latest
     container:
-      image: ruby:3.2
+      image: ruby:3.3
     services:
       db:
         image: postgres:11
@@ -39,10 +39,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmica_version: ["v2.4.0", "master"]
+        redmica_version: ["v3.0.1", "master"]
     runs-on: ubuntu-latest
     container:
-      image: ruby:3.2
+      image: ruby:3.3
     services:
       db:
         image: mysql:5
@@ -70,10 +70,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmica_version: ["v2.4.0", "master"]
+        redmica_version: ["v3.0.1", "master"]
     runs-on: ubuntu-latest
     container:
-      image: ruby:3.2
+      image: ruby:3.3
     steps:
       - uses: actions/checkout@v3
       - name: Setup


### PR DESCRIPTION
This PR includes the following changes:

* Change the test target to RedMica 3.0.1 and Ruby 3.3
* Add a temporary workaround to avoid test failures due to [the change from unprocessable_entity to unprocessable_content in Rack 3.1.0](https://github.com/rack/rack/pull/2137)
  * In Rack 3.1.0 and later, all tests to verify that the response code is `:unprocesable_entity` fail. More info: https://github.com/hidakatsuya/redmica_ui_extension/actions/runs/9756212264/job/26926081378
  * This has been resolved in [the Redmine master branch](https://github.com/redmine/redmine/commit/b803bddb1f32842b0a5ec93640778d902b5f7999), but not yet in RedMica.