### PR TITLE
Update actions/checkout to v4 to suppress the warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup
         run: |
           chmod +x /__w/redmica_ui_extension/redmica_ui_extension/.github/scripts/setup-redmica.sh
@@ -50,7 +50,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: password
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup
         run: |
           chmod +x /__w/redmica_ui_extension/redmica_ui_extension/.github/scripts/setup-redmica.sh
@@ -77,7 +77,7 @@ jobs:
     container:
       image: ruby:3.3
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup
         run: |
           chmod +x /__w/redmica_ui_extension/redmica_ui_extension/.github/scripts/setup-redmica.sh


### PR DESCRIPTION
This PR updates to [actions/checkout](https://github.com/actions/checkout) version to v4. This will suppress the following warnings.
![image](https://github.com/user-attachments/assets/89403609-85b7-45bf-8d2f-c2c9040d9211)
