### PR TITLE
Fix broken preview link rendering in the issue list view

### DIFF
--- a/lib/preview_attachment/application_helper_patch.rb
+++ b/lib/preview_attachment/application_helper_patch.rb
@@ -33,9 +33,9 @@ module PreviewAttachment
 
         filename = attachment.filename
         url = download_named_attachment_url(attachment, { filename: filename })
-        content_tag('span', '', :class => 'preview-attachment icon-only icon-zoom-in',
+        link_to('', '#', :class => 'preview-attachment icon-only icon-zoom-in',
                     :data => { :bp => filename, :bp_src => bp_src, :url => url },
-                    :onclick => 'previewAttachment(this)') + original_link
+                    :onclick => 'previewAttachment(this);return false;') + original_link
       end
     end
   end

--- a/test/helpers/application_helper_patch_test.rb
+++ b/test/helpers/application_helper_patch_test.rb
@@ -48,12 +48,8 @@ class ApplicationHelperPatchTest < Redmine::HelperTest
 
   def test_link_to_attachment_should_return_preview_link_when_setting_is_enabled_and_class_option_includes_icon_download
     with_settings :plugin_redmica_ui_extension => {'preview_attachment' => {'enabled' => 1}} do
-      original_link = '<a class="icon-download" href="/attachments/download/3/logo.gif">logo.gif</a>'.html_safe
-      preview_link = content_tag('span', '', :class => 'preview-attachment icon-only icon-zoom-in',
-                                 :data => { :bp => 'logo.gif',
-                                            :bp_src => 'imgSrc',
-                                            :url => 'http://test.host/attachments/download/3/logo.gif' },
-                                 :onclick => 'previewAttachment(this)')
+      original_link = '<a class="icon-download" href="/attachments/download/3/logo.gif">logo.gif</a>'
+      preview_link = '<a class="preview-attachment icon-only icon-zoom-in" data-bp="logo.gif" data-bp-src="imgSrc" data-url="http://test.host/attachments/download/3/logo.gif" onclick="previewAttachment(this);return false;" href="#"></a>'
       assert_equal(
         preview_link + original_link,
         link_to_attachment(@attachment, {:download => true, :class => 'icon-download'}))


### PR DESCRIPTION
When the "Make attachments previewable" feature of redmica_ui_extension is enabled, adding a Files column to the issue list causes the preview link to not display correctly.

|  before change  |  after change  |
| ---- | ---- |
|  <img width="618" alt="screenshot 2024-09-11 9 00 21" src="https://github.com/user-attachments/assets/020d57a6-1356-4e93-afee-7e972f4bb6d2"> |  <img width="618" alt="screenshot 2024-09-11 9 00 40" src="https://github.com/user-attachments/assets/1d3a3340-5add-4c03-b26a-f86d0662d9d5">  |

**Reproduction steps:**
Enable the "Make attachments previewable" feature in redmica_ui_extension.
Navigate to the issue list view.
Add a Files column to the issue list.
Observe that the preview link is not rendered correctly.

**Fix:**
This pull request resolves the rendering problem by changing the preview link from a span to an a tag.
I considered changing it to a div, but since we had to rewrite the CSS to display the pointer, I decided to use an a tag so that the change would be minimal.

**Note:**
* link_to_attachment is also used in other views, such as issues/show