### PR TITLE
Fix mermaid macro SVG size issue

### DIFF
--- a/assets/stylesheets/mermaid_macro/mermaid_macro.css
+++ b/assets/stylesheets/mermaid_macro/mermaid_macro.css
@@ -10,3 +10,8 @@
 .mermaid .task {
   height: 20px;
 }
+
+div.mermaid svg {
+  width: initial;
+  height: initial;
+}


### PR DESCRIPTION
This pull request fixes the issue where the mermaid macro's SVG does not display when using this plugin with the latest version of Redmine.
The root cause of the issue is that the SVG's width and height are set to `0`, as defined in [this Redmine stylesheet](https://github.com/redmine/redmine/blob/master/app/assets/stylesheets/application.css#L1666-L1668).
This pull request resolves the issue by overriding the mermaid SVG's width and height to `initial`, ensuring that the SVG will render with correct size.

To prevent this issue from occurring again in the future, I have also added a test that verifies the SVG is displayed correctly, and that its width and height are not set to `0`.
* The test will fail if run without the CSS changes.
* After applying the changes, the test will pass as the SVG will render with a width of `128.234375` and a height of `248`, confirming the fix.