### PR TITLE
Fix incorrect svg size in responsive mode

### DIFF
--- a/assets/stylesheets/mermaid_macro/mermaid_macro.css
+++ b/assets/stylesheets/mermaid_macro/mermaid_macro.css
@@ -11,7 +11,7 @@
   height: 20px;
 }
 
+/* Fix https://github.com/mermaid-js/mermaid/issues/1984 */
 div.mermaid svg {
-  width: initial;
-  height: initial;
+  height: auto;
 }


### PR DESCRIPTION
This PR fixes two issues related to div.mermaid svg styling in responsive mode:

* Width issue: In responsive mode, it is correct for the width to change from width: initial to width: 100% to properly adapt to the screen size. To ensure this transition is not blocked, the overriding `width: initial;` style has been removed.
* Height issue: The height remains fixed based on the screen width before entering responsive mode, causing it to exceed the required dimensions and leaving unnecessary blank spaces. To prevent this, the original style has been overridden with `height: auto;`.