### PR TITLE
Support for SVG icons in Redmine6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmica_version: ["v3.0.1", "master"]
+        redmica_version: ["master"]
     runs-on: ubuntu-latest
     container:
       image: ruby:3.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmica_version: ["v3.0.1", "master"]
+        redmica_version: ["master"]
     runs-on: ubuntu-latest
     container:
       image: ruby:3.3
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmica_version: ["v3.0.1", "master"]
+        redmica_version: ["master"]
     runs-on: ubuntu-latest
     container:
       image: ruby:3.3

--- a/init.rb
+++ b/init.rb
@@ -7,6 +7,7 @@ Redmine::Plugin.register :redmica_ui_extension do
   name 'RedMica UI extension'
   author 'Far End Technologies Corporation'
   description 'This plugin adds useful UI improvements.'
+  requires_redmine version_or_higher: '6.0'
   version '0.3.9'
   url 'https://github.com/redmica/redmica_ui_extension'
   author_url 'https://github.com/redmica'

--- a/lib/preview_attachment/application_helper_patch.rb
+++ b/lib/preview_attachment/application_helper_patch.rb
@@ -33,7 +33,7 @@ module PreviewAttachment
 
         filename = attachment.filename
         url = download_named_attachment_url(attachment, { filename: filename })
-        link_to('', '#', :class => 'preview-attachment icon-only icon-zoom-in',
+        link_to(sprite_icon('zoom-in'), '#', :class => 'preview-attachment icon-only icon-zoom-in',
                     :data => { :bp => filename, :bp_src => bp_src, :url => url },
                     :onclick => 'previewAttachment(this);return false;') + original_link
       end

--- a/test/helpers/application_helper_patch_test.rb
+++ b/test/helpers/application_helper_patch_test.rb
@@ -49,7 +49,7 @@ class ApplicationHelperPatchTest < Redmine::HelperTest
   def test_link_to_attachment_should_return_preview_link_when_setting_is_enabled_and_class_option_includes_icon_download
     with_settings :plugin_redmica_ui_extension => {'preview_attachment' => {'enabled' => 1}} do
       original_link = '<a class="icon-download" href="/attachments/download/3/logo.gif">logo.gif</a>'
-      preview_link = '<a class="preview-attachment icon-only icon-zoom-in" data-bp="logo.gif" data-bp-src="imgSrc" data-url="http://test.host/attachments/download/3/logo.gif" onclick="previewAttachment(this);return false;" href="#"></a>'
+      preview_link = '<a class="preview-attachment icon-only icon-zoom-in" data-bp="logo.gif" data-bp-src="imgSrc" data-url="http://test.host/attachments/download/3/logo.gif" onclick="previewAttachment(this);return false;" href="#"><svg class="s18 icon-svg" aria-hidden="true"><use href="/assets/icons-903cd898.svg#icon--zoom-in"></use></svg></a>'
       assert_equal(
         preview_link + original_link,
         link_to_attachment(@attachment, {:download => true, :class => 'icon-download'}))


### PR DESCRIPTION
This pull request replace icon 'zoom-in" to SVG image for attachment preview links that's provided by this plugin.

### Attachment preview improvements using SVG icon on Redmine6:

* [`lib/preview_attachment/application_helper_patch.rb`](diffhunk://#diff-bc2fba562e08da3a4e0602220563b38e884173ff2f0415ace357bb226c7496b2L36-R36): Updated the `link_to_attachment` method to use the `sprite_icon` helper for the zoom-in icon, enhancing the attachment preview link.
* [`test/helpers/application_helper_patch_test.rb`](diffhunk://#diff-a5ac8b58555b79516fb065069fb321e0803ad5050cda5d3c0a9bab3e2b54487eL52-R52): Modified the test for `link_to_attachment` to reflect the changes in the attachment preview link, ensuring the SVG icon is correctly included in the generated HTML.

### Dependency update:

* [`init.rb`](diffhunk://#diff-4afdb3c3c34a069c37756ebaee5883f21565d29c7730ba4565b88aa809d226ccR10): Added a requirement for Redmine version 6.0 or higher.