### PR TITLE
Add CI environment using RedMica3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmica_version: ["master"]
+        redmica_version: ["v3.1.0", "master"]
     runs-on: ubuntu-latest
     container:
       image: ruby:3.3
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmica_version: ["master"]
+        redmica_version: ["v3.1.0", "master"]
     runs-on: ubuntu-latest
     container:
       image: ruby:3.3
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmica_version: ["master"]
+        redmica_version: ["v3.1.0", "master"]
     runs-on: ubuntu-latest
     container:
       image: ruby:3.3


### PR DESCRIPTION
This pull request includes a small change to the .github/workflows/test.yml file. The change adds a new matrix configuration for testing with the stable version 3.1 of the RedMica repository.

* Updated `redmica_version` matrix to include version "v3.1.0" alongside "master" in three job configurations. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L8-R8) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L43-R43) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L75-R75)