### PR TITLE
Fix the test so that it works even if the icon path changes

### DIFF
--- a/test/helpers/application_helper_patch_test.rb
+++ b/test/helpers/application_helper_patch_test.rb
@@ -49,10 +49,11 @@ class ApplicationHelperPatchTest < Redmine::HelperTest
   def test_link_to_attachment_should_return_preview_link_when_setting_is_enabled_and_class_option_includes_icon_download
     with_settings :plugin_redmica_ui_extension => {'preview_attachment' => {'enabled' => 1}} do
       original_link = '<a class="icon-download" href="/attachments/download/3/logo.gif">logo.gif</a>'
-      preview_link = '<a class="preview-attachment icon-only icon-zoom-in" data-bp="logo.gif" data-bp-src="imgSrc" data-url="http://test.host/attachments/download/3/logo.gif" onclick="previewAttachment(this);return false;" href="#"><svg class="s18 icon-svg" aria-hidden="true"><use href="/assets/icons-903cd898.svg#icon--zoom-in"></use></svg></a>'
-      assert_equal(
-        preview_link + original_link,
-        link_to_attachment(@attachment, {:download => true, :class => 'icon-download'}))
+      result = link_to_attachment(@attachment, {:download => true, :class => 'icon-download'})
+
+      assert_includes result, original_link
+      assert_match %r{<a class="preview-attachment .*?icon-zoom-in"}, result
+      assert_match %r{data-url="http://test\.host/attachments/download/3/logo\.gif"}, result
     end
   end
 end


### PR DESCRIPTION
Fix the test so that it does not fail as follows:
```
Failure:
ApplicationHelperPatchTest#test_link_to_attachment_should_return_preview_link_when_setting_is_enabled_and_class_option_includes_icon_download [plugins/redmica_ui_extension/test/helpers/application_helper_patch_test.rb:53]:
--- expected
+++ actual
@@ -1 +1 @@
-"<a class=\"preview-attachment icon-only icon-zoom-in\" data-bp=\"logo.gif\" data-bp-src=\"imgSrc\" data-url=\"http://test.host/attachments/download/3/logo.gif\" onclick=\"previewAttachment(this);return false;\" href=\"#\"><svg class=\"s18 icon-svg\" aria-hidden=\"true\"><use href=\"/assets/icons-903cd898.svg#icon--zoom-in\"></use></svg></a><a class=\"icon-download\" href=\"/attachments/download/3/logo.gif\">logo.gif</a>"
+"<a class=\"preview-attachment icon-only icon-zoom-in\" data-bp=\"logo.gif\" data-bp-src=\"imgSrc\" data-url=\"http://test.host/attachments/download/3/logo.gif\" onclick=\"previewAttachment(this);return false;\" href=\"#\"><svg class=\"s18 icon-svg\" aria-hidden=\"true\"><use href=\"/assets/icons-8e2df87b.svg#icon--zoom-in\"></use></svg></a><a class=\"icon-download\" href=\"/attachments/download/3/logo.gif\">logo.gif</a>"


bin/rails test plugins/redmica_ui_extension/test/helpers/application_helper_patch_test.rb:49
```

The reason for the failure is that the variable value icon-xxxxx.svg was written directly, so we will use a regular expression to check only the necessary parts.