### PR TITLE
Adjust searchable select box width to match original select element

### DIFF
--- a/assets/stylesheets/searchable_selectbox/searchable_selectbox.css
+++ b/assets/stylesheets/searchable_selectbox/searchable_selectbox.css
@@ -42,8 +42,7 @@ fieldset#filters td.values .select2-container--default {
   min-width: 100px;
 }
 .tabular .splitcontent .select2-container {
-  width: 75%;
-  max-width: 300px;
+  width: 60%; /* Match the width of the select element before applying select2 */
 }
 #add_filter_select + .select2-container,
 #group_by + .select2-container {


### PR DESCRIPTION
This PR changes the `.select2-container` width from **75%** to **60%** to improve alignment with the original `<select>` element before applying Select2.

### Changes  
- Updated `searchable_selectbox.css` to set `.select2-container` width to `60%`.  
- Since the max-width definition effectively made the display at 300px, that definition will be removed.
- This change ensures a more consistent UI without overly restricting the select box width.

## Before & After & Original selectbox(without select2) 

When the screen width is small:
| Before (75%, ~max 300px~) | After (60%) |Original selectbox|
|--------------|--------------|------------|
| <img width="200" alt="screenshot 2025-02-12 11 33 35" src="https://github.com/user-attachments/assets/0e648137-91ec-440a-837c-6c1e95dea018" />|<img width="200" alt="screenshot 2025-02-12 11 33 50" src="https://github.com/user-attachments/assets/104c210d-37e8-406a-89c3-c1b6a424f597" />|<img width="200" alt="screenshot 2025-02-12 11 34 06" src="https://github.com/user-attachments/assets/e95c51ab-ad39-40e5-8bf4-90270bce3ee5" />|

When the screen width is large:
| Before (~75%~, max 300px) | After (60%) |Original selectbox|
|--------------|--------------|------------|
<img width="897" alt="screenshot 2025-02-12 11 41 06" src="https://github.com/user-attachments/assets/589595d9-bba2-4e00-b2e5-596ad0b162db" />|<img width="897" alt="screenshot 2025-02-12 11 40 47" src="https://github.com/user-attachments/assets/05a3c363-44da-43e9-9634-fc10edca0f68" />|<img width="897" alt="screenshot 2025-02-12 11 41 22" src="https://github.com/user-attachments/assets/5b5a9e14-e124-45f9-8992-c25a46481351" />| 