### PR TITLE
Upgrade actions/upload-artifact from v3 to v4 to resolve deprecation notice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Test RedMica UI Extension plugin
         run: cd /usr/src/redmine; RAILS_ENV=test bundle exec rake test TEST=plugins/redmica_ui_extension/test
       - name: Store screenshots Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-postgres-${{ matrix.redmica_version }}-screenshots
@@ -58,7 +58,7 @@ jobs:
       - name: Test RedMica UI Extension plugin
         run: cd /usr/src/redmine; RAILS_ENV=test bundle exec rake test TEST=plugins/redmica_ui_extension/test
       - name: Store screenshots Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-mysql-${{ matrix.redmica_version }}-screenshots
@@ -85,7 +85,7 @@ jobs:
       - name: Test RedMica UI Extension plugin
         run: cd /usr/src/redmine; RAILS_ENV=test bundle exec rake test TEST=plugins/redmica_ui_extension/test
       - name: Store screenshots Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-sqlite-${{ matrix.redmica_version }}-screenshots


### PR DESCRIPTION
GitHub Actions tests are currently failing due to `actions/upload-artifact@v3` being deprecated.  
This PR updates it to `actions/upload-artifact@v4` to resolve the issue and ensure the workflow runs successfully.

failed test: https://github.com/redmica/redmica_ui_extension/actions/runs/13276915666
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

### Changes  
- Updated `actions/upload-artifact` from `v3` to `v4` in the workflow files.