### PR TITLE
Remove max-width style for select2 select box

### DIFF
--- a/assets/stylesheets/searchable_selectbox/searchable_selectbox.css
+++ b/assets/stylesheets/searchable_selectbox/searchable_selectbox.css
@@ -43,7 +43,6 @@ fieldset#filters td.values .select2-container--default {
 }
 .tabular .splitcontent .select2-container {
   width: 75%;
-  max-width: 300px;
 }
 #add_filter_select + .select2-container,
 #group_by + .select2-container {


### PR DESCRIPTION
I will remove the max-width setting that was previously applied to the select box when the "Make the selection box searchable" option was enabled.

Due to this max-width setting, the width of the select box did not increase beyond 300px, even when the screen width was larger. As a result, long options that did not fit within the select box could only be fully viewed by opening the dropdown.

|before|after|
|---|---|
|<img width="1920" alt="screenshot 2025-03-03 15 19 18" src="https://github.com/user-attachments/assets/346de7a1-d68f-4f23-a143-bfb893e06180" />|<img width="1920" alt="screenshot 2025-03-03 15 17 56" src="https://github.com/user-attachments/assets/6cb78c51-249a-439d-8087-ce822e4b7f9d" />|