### PR TITLE
Enhance readability by adjusting font styles in searchable selectbox

### DIFF
--- a/assets/stylesheets/searchable_selectbox/searchable_selectbox.css
+++ b/assets/stylesheets/searchable_selectbox/searchable_selectbox.css
@@ -8,21 +8,18 @@
   vertical-align: middle;
   margin-top: 1px;
   margin-bottom: 1px;
-  font: 400 11px system-ui;
   border: 1px solid #ccc;
   border-radius: 3px;
   height: 24px;
-  font-family: Verdana, sans-serif;
+}
+
+.select2-results__option, .select2-container--default .select2-selection--single {
+  font-size: 13.3333px; /* Match the font size to the input */
 }
 
 .select2-container--default .select2-selection--single:focus {
   border: 1px solid #5ad;
   outline: none;
-}
-
-.select2-results__option {
-  font: 400 11px system-ui;
-  font-family: Verdana, sans-serif;
 }
 
 .select2-container--default .select2-selection--single .select2-selection__rendered {


### PR DESCRIPTION
Adjusted the font size and font settings for the searchable select box.  

### Changes  
- Unified the font size of `.select2-results__option` to `13.3333px` to match the input field.  
- Applied the same `13.3333px` font size to `.select2-container--default .select2-selection--single`.  
- Removed the `font-family` override to allow themes and global styles to be applied.  

### Purpose of the Change  
- The font size was previously set to `11px`, making it smaller than the surrounding elements. It has been adjusted to `13.3333px` to match the input field and improve readability.  
- Removing the font override allows for better adaptability to themes and global style settings.  

### Screenshots

|  before  |  after  |
| ---- | ---- |
| <img width="793" alt="screenshot 2025-03-10 13 55 54" src="https://github.com/user-attachments/assets/0063aa03-c316-4ce1-8fd7-41550c2148a7" />  |  <img width="793" alt="screenshot 2025-03-10 13 55 41" src="https://github.com/user-attachments/assets/dc7bd2b2-6728-4bfe-9330-2442bf7093c2" />|