### PR TITLE
Pin Playwright versions and update Playwright setup

### DIFF
--- a/.github/scripts/setup-redmica.sh
+++ b/.github/scripts/setup-redmica.sh
@@ -45,9 +45,9 @@ apt-get update && apt-get install -y ca-certificates curl gnupg
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 apt-get update && apt-get install nodejs -y
-npm install playwright
-npx playwright install chromium
-npx playwright install-deps
+npm --prefix plugins/redmica_ui_extension install
+npx --prefix plugins/redmica_ui_extension playwright install chromium
+npx --prefix plugins/redmica_ui_extension playwright install-deps
 
 # PDFのサムネイル作成テストを成功させるため
 sed -i 's/^.*policy.*coder.*none.*PDF.*//' /etc/ImageMagick-6/policy.xml

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'capybara-playwright-driver'
-  gem 'playwright-ruby-client'
+  gem 'capybara-playwright-driver', '0.5.9'
+  gem 'playwright-ruby-client', '1.58.1'
 end

--- a/README.md
+++ b/README.md
@@ -66,11 +66,14 @@ $ git clone https://github.com/redmica/redmica_ui_extension.git /path/to/redmine
 ```
 ## Test
 
+Run the following commands from your Redmine root:
+
 ```
 $ # for system test
-$ npm install playwright
-$ npx playwright install chromium
-$ npx playwright install-deps
+$ bundle install
+$ npm --prefix plugins/redmica_ui_extension install
+$ npx --prefix plugins/redmica_ui_extension playwright install chromium
+$ npx --prefix plugins/redmica_ui_extension playwright install-deps
 $ RAILS_ENV=test bundle exec rake test TEST=plugins/redmica_ui_extension/test
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "dependencies": {},
   "devDependencies": {
-    "playwright": "^1.40.1"
+    "playwright": "1.58.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "playwright": "1.58.1"
+    "playwright": "1.58.2"
   }
 }

--- a/test/playwright_system_test_case.rb
+++ b/test/playwright_system_test_case.rb
@@ -3,7 +3,16 @@
 require_relative '../../../test/test_helper'
 
 class PlaywrightSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by(:playwright, options: { headless: true, browser_type: :chromium })
+  PLAYWRIGHT_CLI = File.expand_path('../node_modules/.bin/playwright', __dir__)
+
+  driven_by(
+    :playwright,
+    options: {
+      headless: true,
+      browser_type: :chromium,
+      playwright_cli_executable_path: PLAYWRIGHT_CLI
+    }
+  )
 
   # Should not depend on locale since Redmine displays login page
   # using default browser locale which depend on system locale for "real" browsers drivers


### PR DESCRIPTION
## Purpose

Pin the Playwright-related dependency versions so that system tests do not become unstable due to environment differences.

## Implementation

- Pin playwright in package.json to 1.58.1, capybara-playwright-driver in Gemfile to 0.5.9, and playwright-ruby-client to 1.58.1
- Explicitly set playwright_cli_executable_path so system tests use the Playwright CLI under the plugin directory
- Update the README setup instructions so they can be run from the Redmine root while pointing to the plugin directory

## Notes

Previously, tests always ran with the latest Playwright version. After this change, the Playwright version will need to be updated manually from time to time.