### PR TITLE
Apply searchable selectbox setting to block_select_tag

### DIFF
--- a/lib/searchable_selectbox/my_helper_patch.rb
+++ b/lib/searchable_selectbox/my_helper_patch.rb
@@ -11,10 +11,10 @@ module SearchableSelectbox
     module InstanceMethods
       # Run replaceSelect2(); when remove_block.js.erb
       def block_select_tag(user)
-        super(user) +
-        javascript_tag do
-          '$(function(){replaceSelect2();});'
-        end
+        tag = super(user)
+        return tag unless Setting.enabled_redmica_ui_extension_feature?('searchable_selectbox')
+
+        tag + javascript_tag { '$(function(){replaceSelect2();});' }
       end
     end
   end

--- a/test/helpers/my_helper_patch_test.rb
+++ b/test/helpers/my_helper_patch_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../../../../test/test_helper'
+
+class MyHelperPatchTest < Redmine::HelperTest
+  include MyHelper
+
+  def setup
+    @user = User.find(2)
+  end
+
+  def test_block_select_tag_should_not_include_replace_select2_script_when_setting_is_disabled
+    with_settings :plugin_redmica_ui_extension => {'searchable_selectbox' => {'enabled' => 0}} do
+      refute_includes block_select_tag(@user), 'replaceSelect2();'
+    end
+  end
+
+  def test_block_select_tag_should_include_replace_select2_script_when_setting_is_enabled
+    with_settings :plugin_redmica_ui_extension => {'searchable_selectbox' => {'enabled' => 1}} do
+      assert_includes block_select_tag(@user), 'replaceSelect2();'
+    end
+  end
+end


### PR DESCRIPTION
## Purpose

Even when the searchable select box feature was disabled, replaceSelect2(); was still being added to the block selector on My page, so the actual behavior did not match the plugin setting.
This change makes block_select_tag respect the searchable_selectbox setting.

This pull request fixes the issue reported in #75.

## Implementation

- Updated MyHelperPatch#block_select_tag to append replaceSelect2(); only when searchable_selectbox is enabled
- Changed the method to return the result of super(user) as-is when the feature is disabled
- Added helper tests to verify the output of block_select_tag for both enabled and disabled settings

## Notes

- The behavior change only affects the disabled case, and there is no change when searchable_selectbox is enabled
