### PR TITLE
Add dropdownAutoWidth to Select2 initialization

### DIFF
--- a/assets/javascripts/searchable_selectbox/searchable_selectbox.js
+++ b/assets/javascripts/searchable_selectbox/searchable_selectbox.js
@@ -48,7 +48,7 @@ $(function() {
     var oldAddFilter = window.addFilter;
     window.addFilter = function(field, operator, values){
       oldAddFilter(field, operator, values);
-      $('#filters-table select:not([multiple]):not([data-remote]):not(.select2-hidden-accessible)').select2();
+      $('#filters-table select:not([multiple]):not([data-remote]):not(.select2-hidden-accessible)').select2({dropdownAutoWidth: true});
       $('#select2-add_filter_select-container.select2-selection__rendered').text('');
     }
 
@@ -58,7 +58,7 @@ $(function() {
       if (el.attr('multiple')) {
         el.select2('destroy');
       } else {
-        el.select2();
+        el.select2({dropdownAutoWidth: true});
       }
     }
   }
@@ -78,7 +78,8 @@ function replaceSelect2() {
     }
     if (selectInTabular.length) {
       selectInTabular.select2({
-        width: 'style'
+        width: 'style',
+        dropdownAutoWidth: true
       }).on('select2:select', function() {
         retriggerChangeIfNativeEventExists($(this));
       });
@@ -86,7 +87,9 @@ function replaceSelect2() {
 
     var other = $('select:not([multiple]):not([data-remote]):not(.select2-hidden-accessible)');
     if (other.length) {
-      other.select2().on('select2:select', function() {
+      other.select2({
+        dropdownAutoWidth: true
+      }).on('select2:select', function() {
         retriggerChangeIfNativeEventExists($(this));
       });
     }


### PR DESCRIPTION
## Purpose
Improve Select2 dropdown rendering by enabling automatic dropdown width adjustment where searchable select boxes are initialized.

##  Implementation
- Added `dropdownAutoWidth: true` to Select2 initialization in searchable select box scripts.
- Applied the option in all relevant initialization paths:
  - `replaceSelect2()` for tabular and non-tabular single selects.
  - `addFilter` hook for dynamically added issue filters.
  - `toggleMultiSelect` hook when switching back to single select.
- Kept existing behavior intact (same targets and event hooks), only adjusted Select2 options.

## Screenshots

Before change:
<img width="266" height="190" alt="screenshot 2026-04-22 14 31 54" src="https://github.com/user-attachments/assets/423a3271-288b-4560-9adb-cc33ee658d1f" />

After change:
<img width="269" height="154" alt="screenshot 2026-04-22 14 31 31" src="https://github.com/user-attachments/assets/82793f07-8279-4801-a36f-d63689a9ffc6" />

## Notes for Reviewers
- This is a UI option change only.
- Since the Select2 application and selection flow are already fully covered by existing system tests, no new tests have been added. This change is intended to fine-tune the behavior regarding the width of the dropdown menu, and we believe that the functionality of the options has been thoroughly tested on the Select2 side.
