### PR TITLE
Match selected option background color to the Redmine default theme

### DIFF
--- a/assets/stylesheets/searchable_selectbox/searchable_selectbox.css
+++ b/assets/stylesheets/searchable_selectbox/searchable_selectbox.css
@@ -73,7 +73,7 @@ fieldset#filters td.values .select2-container--default {
   outline: none;
 }
 li.select2-results__option--highlighted[role="option"][aria-selected] {
-  background-color: #759FC2;
+  background-color: var(--oc-blue-7, #1c7ed6);
   color: #fff;
 }
 .select2-dropdown {


### PR DESCRIPTION
## Summary
Align the selected option background color in searchable_selectbox with the Redmine default theme to keep highlight styling consistent across the UI.

## Changes
- Changed background-color in `li.select2-results__option--highlighted[role="option"][aria-selected]` from `#759FC2` to `#1c7ed6`

## Screenshot

before change (Redmine default theme)
<img width="632" height="205" alt="screenshot 2026-05-07 9 31 50" src="https://github.com/user-attachments/assets/4908039c-ef11-48f4-b978-73869a5f8e61" />

after change (Redmine default theme)
<img width="632" height="205" alt="screenshot 2026-05-07 9 31 10" src="https://github.com/user-attachments/assets/91610ddb-f39a-4663-8b4e-8ac15b4dbd35" />

