### PR TITLE
Update RedMica test target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
             redmine-version: 'master'
             ruby-version: '3.4'
           - redmine-repository: 'redmica/redmica'
-            redmine-version: 'stable-4.0'
+            redmine-version: 'stable-4.1'
             ruby-version: '3.4'
 
     steps:


### PR DESCRIPTION
This PR changes the RedMica test target from stable-4.0 to stable-4.1.